### PR TITLE
fix(ci): unbreak integration tests (\\restrict + trigram)

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -2,8 +2,6 @@
 -- PostgreSQL database dump
 --
 
-\restrict k4iGve5kCwmnia3ytjVw6sdgeU63VI4SURze5YbfBckUP6PSjM4FpxGp5j4N8xU
-
 -- Dumped from database version 16.13 (Homebrew)
 -- Dumped by pg_dump version 16.13 (Homebrew)
 
@@ -1028,6 +1026,4 @@ ALTER TABLE ONLY public.relationships
 --
 -- PostgreSQL database dump complete
 --
-
-\unrestrict k4iGve5kCwmnia3ytjVw6sdgeU63VI4SURze5YbfBckUP6PSjM4FpxGp5j4N8xU
 

--- a/tests/integration/test_memory_query.py
+++ b/tests/integration/test_memory_query.py
@@ -116,8 +116,9 @@ def test_trigram_search_on_content(db_connection):
 
         cur.execute(
             "SELECT content FROM memory_chunks "
-            "WHERE content %% 'streamlit' "
-            "ORDER BY similarity(content, 'streamlit') DESC"
+            "WHERE content %% %s "
+            "ORDER BY similarity(content, %s) DESC",
+            ("streamlit", "streamlit"),
         )
         hits = [r[0] for r in cur.fetchall()]
         assert any("streamlit dashboard" in h.lower() for h in hits)


### PR DESCRIPTION
## Summary

**Fixes the pre-existing red \"Integration tests (Postgres)\" CI job on main.** Two small, related fixes:

### 1. Strip PG17 \`\\restrict\` directives from \`sql/schema.sql\`

\`tests/integration/conftest.py\` loads the schema through psycopg2, which executes the file as raw SQL. The \`\\restrict\` / \`\\unrestrict\` lines are psql 17 meta-commands, not SQL — psycopg2 chokes with \`syntax error at or near \"\\\"\` and **every integration test errors at fixture setup**.

Removes:
- Line 5: \`\\restrict <token>\`
- Line 1030: \`\\unrestrict <token>\`

These directives are PG17 features for guarding scripts; they aren't part of the schema definition. Removing them does not change a single \`CREATE\` / \`ALTER\` / \`INDEX\` statement.

### 2. Fix the trigram test's \`%%\` escape

\`tests/integration/test_memory_query.py::test_trigram_search_on_content\` calls \`cur.execute()\` with **no params tuple**, but the SQL contains \`WHERE content %% 'streamlit'\`. psycopg2 only interprets \`%%\` as an escape when params are passed; without params, the literal \`%%\` reaches Postgres, which has no \`%%\` operator (\`operator does not exist: text %% unknown\`).

Fix: switch to parameterised form so \`%%\` is now the escape for the pg_trgm \`%\` operator and the term passes through \`%s\`. Behaviour identical.

## Effect

Before: 0/8 integration tests pass (8 errors at fixture setup).
After fix #1: 7/8 pass (trigram test still fails for unrelated reason).
After fix #2: **8/8 pass.**

## Diff

\`\`\`
sql/schema.sql                            | 4 ----
tests/integration/test_memory_query.py    | 5 +++--
2 files changed, 3 insertions(+), 6 deletions(-)
\`\`\`

## Why land first

PRs #1, #2, #3 all show \"Integration tests (Postgres)\" failing — same pre-existing failure inherited from main. After this PR lands, rebasing the others onto the new main will turn their CI green.

## Regen note

If \`sql/schema.sql\` is ever regenerated via pg_dump 17, strip the directives in the same step:

\`\`\`bash
pg_dump --schema-only --no-owner --no-privileges <DB> \\
  | grep -v '^\\\\restrict ' | grep -v '^\\\\unrestrict ' \\
  > sql/schema.sql
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)