### PR TITLE
feat: forget primitive (cascade-delete + audit) [reopen]

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -30,6 +30,10 @@ except Exception:
 _DEFAULT_PROJECT_ROOT = Path(_GUI_DIR).resolve().parent
 PROJECT_ROOT = Path(os.environ.get("CLAUDE_MEMORY_ROOT", str(_DEFAULT_PROJECT_ROOT))).resolve()
 SCRIPTS_ROOT = PROJECT_ROOT / "scripts"
+if str(SCRIPTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_ROOT))
+
+from forget import forget_chunks, forget_entity  # noqa: E402
 
 # ══════════════════════════════════════════════════════════════════════════════
 # CONFIG
@@ -889,9 +893,22 @@ elif detail_type == "memory":
                 unsafe_allow_html=True,
             )
         with head_r:
-            if st.button("Delete", key=f"del_m_{mc_id}", use_container_width=True):
-                dml("DELETE FROM memory_chunks WHERE id = %s", (mc_id,))
-                go_back()
+            if st.button(
+                "Forget",
+                key=f"del_m_{mc_id}",
+                use_container_width=True,
+                help="Cascade-delete this chunk and its embeddings, with audit row in memory_reflections.",
+            ):
+                try:
+                    res = forget_chunks(_live_conn(), [mc_id], reason="GUI memory detail forget")
+                    st.toast(
+                        f"Forgotten — {res['chunks']} chunk(s), "
+                        f"{res['embeddings']} embedding(s) — audit #{res['reflection_id']}"
+                    )
+                except Exception as e:
+                    st.toast(f"Error: {e}", icon="⚠️")
+                else:
+                    go_back()
 
         st.markdown('<hr/>', unsafe_allow_html=True)
 
@@ -1073,9 +1090,22 @@ elif detail_type == "entity":
                 unsafe_allow_html=True,
             )
         with head_r:
-            if st.button("Delete", key=f"del_e_{ent_id}", use_container_width=True):
-                dml("DELETE FROM entities WHERE id = %s", (ent_id,))
-                go_back()
+            if st.button(
+                "Forget",
+                key=f"del_e_{ent_id}",
+                use_container_width=True,
+                help="Cascade-delete this entity, its mentions and relationships, with audit row in memory_reflections.",
+            ):
+                try:
+                    res = forget_entity(_live_conn(), ent_id, reason="GUI entity detail forget")
+                    st.toast(
+                        f"Forgotten — {res['mentions']} mention(s), "
+                        f"{res['relationships']} rel(s) — audit #{res['reflection_id']}"
+                    )
+                except Exception as e:
+                    st.toast(f"Error: {e}", icon="⚠️")
+                else:
+                    go_back()
 
         st.markdown('<hr/>', unsafe_allow_html=True)
 
@@ -2234,6 +2264,39 @@ elif page == "Memory":
                 )
                 st.toast(msg)
                 st.rerun()
+
+    with st.expander("Forget chunks (cascade-delete with audit)"):
+        with st.form("bulk_forget_mc"):
+            forget_ids_raw = st.text_input(
+                "Chunk IDs",
+                placeholder="e.g. 1234, 1287, 1290 — comma- or space-separated",
+                help="Cascade-deletes each chunk and its embeddings. Logs a row in memory_reflections.",
+            )
+            forget_reason = st.text_input(
+                "Reason (required)",
+                placeholder="Why are these being forgotten? (audit trail)",
+            )
+            if st.form_submit_button("Forget selected", type="primary"):
+                ids: list[int] = []
+                for tok in forget_ids_raw.replace(",", " ").split():
+                    try:
+                        ids.append(int(tok))
+                    except ValueError:
+                        pass
+                if not ids:
+                    st.toast("No valid IDs.", icon="⚠️")
+                elif not forget_reason.strip():
+                    st.toast("Reason is required.", icon="⚠️")
+                else:
+                    try:
+                        res = forget_chunks(_live_conn(), ids, reason=forget_reason.strip())
+                        st.toast(
+                            f"Forgotten {res['chunks']} chunk(s), "
+                            f"{res['embeddings']} embedding(s) — audit #{res['reflection_id']}"
+                        )
+                        st.rerun()
+                    except Exception as e:
+                        st.toast(f"Error: {e}", icon="⚠️")
 
     with st.spinner("Loading memory..."):
         df = q(

--- a/scripts/forget.py
+++ b/scripts/forget.py
@@ -1,0 +1,96 @@
+"""Cascade-delete primitives for memory chunks and entities.
+
+Both functions run in a single transaction and write an audit row to
+`memory_reflections`. The caller owns the connection but does NOT commit —
+these functions commit on success and rollback on failure.
+
+Convention for `memory_reflections.reflection_type`:
+  - 'forget'         — chunk(s) deleted via forget_chunks
+  - 'forget_entity'  — entity deleted via forget_entity (FK cascades take care
+                       of entity_mentions and relationships)
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def forget_chunks(conn, ids: Iterable[int], *, reason: str) -> dict:
+    id_list = [int(i) for i in ids]
+    if not id_list:
+        return {"chunks": 0, "embeddings": 0, "reflection_id": None}
+
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM embeddings WHERE source_type = 'memory_chunk' AND source_id = ANY(%s)",
+                (id_list,),
+            )
+            embeddings_deleted = cur.rowcount
+
+            cur.execute(
+                "UPDATE memory_chunks SET superseded_by = NULL WHERE superseded_by = ANY(%s)",
+                (id_list,),
+            )
+
+            cur.execute(
+                "DELETE FROM memory_chunks WHERE id = ANY(%s)",
+                (id_list,),
+            )
+            chunks_deleted = cur.rowcount
+
+            cur.execute(
+                """
+                INSERT INTO memory_reflections
+                    (reflection_type, affected_chunks, action_taken, reasoning, confidence)
+                VALUES ('forget', %s, 'deleted', %s, 1.0)
+                RETURNING id
+                """,
+                (id_list, reason[:4000]),
+            )
+            reflection_id = cur.fetchone()[0]
+        conn.commit()
+        return {
+            "chunks": chunks_deleted,
+            "embeddings": embeddings_deleted,
+            "reflection_id": reflection_id,
+        }
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def forget_entity(conn, entity_id: int, *, reason: str) -> dict:
+    eid = int(entity_id)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM entity_mentions WHERE entity_id = %s", (eid,))
+            mentions = int(cur.fetchone()[0])
+            cur.execute(
+                "SELECT COUNT(*) FROM relationships WHERE from_entity = %s OR to_entity = %s",
+                (eid, eid),
+            )
+            relationships = int(cur.fetchone()[0])
+
+            cur.execute("DELETE FROM entities WHERE id = %s", (eid,))
+            entity_deleted = cur.rowcount
+
+            cur.execute(
+                """
+                INSERT INTO memory_reflections
+                    (reflection_type, affected_chunks, action_taken, reasoning, confidence)
+                VALUES ('forget_entity', %s, 'deleted', %s, 1.0)
+                RETURNING id
+                """,
+                ([eid], reason[:4000]),
+            )
+            reflection_id = cur.fetchone()[0]
+        conn.commit()
+        return {
+            "entity": entity_deleted,
+            "mentions": mentions,
+            "relationships": relationships,
+            "reflection_id": reflection_id,
+        }
+    except Exception:
+        conn.rollback()
+        raise


### PR DESCRIPTION
**Reopens** previously-closed [#1](https://github.com/mkupermann/throughline/pull/1) — same branch, rebased onto current main (which has #3 MCP server + #4 CI fixes already merged).

## Why this matters now

#3 (MCP server) is **on main but import-broken**: \`memory_mcp/server.py:32\` does \`from forget import forget_chunks\`. Without this PR's \`scripts/forget.py\`, the MCP server fails at startup with \`ModuleNotFoundError\`, and \`memory.forget\` cannot work even with the import bypassed.

## Summary

Adds a first-class **forget** operation that cascades through embeddings + audit trail:

\`scripts/forget.py\`:
- \`forget_chunks(conn, ids, *, reason)\` — deletes chunks, their embeddings (\`source_type='memory_chunk'\`), repairs dangling \`superseded_by\` references, writes \`memory_reflections\` row with \`reflection_type='forget'\`. One transaction.
- \`forget_entity(conn, entity_id, *, reason)\` — deletes entity, FK cascades take care of \`entity_mentions\` + \`relationships\`, writes \`reflection_type='forget_entity'\` audit row.

GUI:
- Memory chunk detail: \`Delete\` → \`Forget\` (cascading + audited).
- Entity detail: same swap.
- Memory page: new \`Forget chunks (cascade-delete with audit)\` expander.

## Schema

No migration. \`memory_reflections.reflection_type\` is free-form text. We add \`'forget'\` and \`'forget_entity'\` to the existing vocabulary.

## Diff

\`\`\`
gui/app.py        | 75 +++++++++++++++++++++++++++++++++++++++----
scripts/forget.py | 96 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
2 files changed, 165 insertions(+), 6 deletions(-)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)