### PR TITLE
fix(test): trigram test trips default similarity_threshold

### DIFF
--- a/tests/integration/test_memory_query.py
+++ b/tests/integration/test_memory_query.py
@@ -114,11 +114,19 @@ def test_trigram_search_on_content(db_connection):
         _insert_chunk(cur, "Postgres is our system of record.", "decision")
         db_connection.commit()
 
+        # Rank all rows by trigram similarity; the streamlit-dashboard row
+        # should rank first. This avoids depending on pg_trgm.similarity_threshold
+        # (default 0.3) which is too strict for a short keyword vs long sentences.
         cur.execute(
-            "SELECT content FROM memory_chunks "
-            "WHERE content %% %s "
-            "ORDER BY similarity(content, %s) DESC",
-            ("streamlit", "streamlit"),
+            "SELECT content, similarity(content, %s) AS sim "
+            "FROM memory_chunks "
+            "ORDER BY sim DESC",
+            ("streamlit",),
         )
-        hits = [r[0] for r in cur.fetchall()]
-        assert any("streamlit dashboard" in h.lower() for h in hits)
+        hits = cur.fetchall()
+        assert hits, "expected at least one row"
+        top_content, top_sim = hits[0]
+        assert "streamlit dashboard" in top_content.lower(), (
+            f"top hit was {top_content!r} with sim={top_sim}"
+        )
+        assert top_sim > 0, f"top similarity should be >0, got {top_sim}"


### PR DESCRIPTION
## Summary

\`tests/integration/test_memory_query.py::test_trigram_search_on_content\` is currently failing on main with \`assert False\` (after #4 unblocked the rest of the integration suite).

Root cause: the test uses pg_trgm's \`%\` operator, which gates results by the global \`pg_trgm.similarity_threshold\` (default \`0.3\`). For a single short keyword (\`'streamlit'\`) compared against multi-word sentences, trigram similarity falls below 0.3 even when the keyword appears verbatim — so the operator returns no rows and the assertion fails.

## Fix

Rewrite the query to rank all rows by \`similarity()\` directly and assert the streamlit-dashboard row is the top hit. Same test intent (verify pg_trgm is loaded and the operator works on \`memory_chunks.content\`), without depending on the global threshold.

\`\`\`
tests/integration/test_memory_query.py | 20 ++++++++++++++------
1 file changed, 14 insertions(+), 6 deletions(-)
\`\`\`

After this lands, the \"Integration tests (Postgres)\" job should be all-green on main for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)