### PR TITLE
chore: bump to v0.2.0 and finalise CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-04-29
+
 ### Added
 
+- **`forget` primitive** (`scripts/forget.py`) — first-class cascade-delete
+  for memory chunks and entities. `forget_chunks(ids, *, reason)` removes
+  the rows AND their embeddings AND repairs dangling `superseded_by`
+  references in one transaction, writing a `memory_reflections` row with
+  `reflection_type='forget'`. `forget_entity(id, *, reason)` does the
+  equivalent for entities (FK cascades through `entity_mentions` and
+  `relationships`) and logs `'forget_entity'`. Wired into the GUI: Memory
+  chunk detail, Knowledge Graph entity detail, and a Memory-page bulk
+  forget expander (mandatory reason field).
+- **MCP server** (`memory_mcp/`) — exposes six stdio tools so Claude Code
+  (or any MCP client) can read and write its own long-term memory:
+  `memory.search`, `memory.recall_entity` (BFS up to 3 hops with optional
+  `relation_types` whitelist), `memory.write`, `memory.supersede` (with
+  audit row), `memory.forget` (calls `scripts/forget.forget_chunks`), and
+  `memory.list_projects`. Project scoping defaults to
+  `basename($CLAUDE_PROJECT_DIR)`; pass `project=""` to opt out and search
+  across projects. Package named `memory_mcp/` to avoid shadowing the
+  official `mcp` SDK and the existing `throughline/` package.
+- **Knowledge Graph keyword search** — text input filters the rendered
+  graph by one or more keywords against entity names, with **Match all
+  words** (AND vs default OR) and **Include neighbors** (1-hop expansion)
+  toggles. Seed matches highlighted with larger nodes, accent-coloured
+  labels and bold borders. Max-nodes ceiling raised 200 → 400.
+- **Universal CSV / Excel / PDF export** — reusable
+  `render_export_buttons()` helper drops three download buttons above
+  every list view: Conversations, Memory, Memory Health (top-accessed +
+  reflections + supersede/merge), Skills, Knowledge Graph entities,
+  Projects, Prompts, every Global Search scope, and every Semantic Search
+  scope. CSV is UTF-8 with BOM; Excel via `openpyxl`; PDF via `reportlab`
+  (landscape A4, repeated header row, alternating row backgrounds, title
+  + timestamp). Missing optional deps degrade gracefully — those buttons
+  disappear and the page surfaces a `pip install` hint. CSV is always
+  available.
 - **PII / secret redaction** in `throughline/pii.py` that runs automatically
   before each transcript is sent to Claude for memory and entity extraction.
   Redacts Anthropic / OpenAI / GitHub / AWS / Google / Slack / Stripe
@@ -16,7 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   assignments, private-key blocks, email addresses, and home-directory
   usernames. Default on. Disable with `THROUGHLINE_REDACT_PII=0` or
   `memory.redact_pii: false`. 18 unit tests in `tests/test_pii.py`.
-- MCP server exposing 10 tools for Claude Code integration (search_memory, search_semantic, get_project_context, get_recent_conversations, get_conversation, list_decisions, find_contact, list_entities, get_entity_relations, add_memory)
 - Linux systemd user-level service units and timers
   (`systemd/throughline-{ingest,extract,backup}.{service,timer}` + install guide in `systemd/README.md`).
 - Schema migrations framework (`sql/migrations/` + `scripts/migrate.py`),
@@ -47,6 +81,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `claude` CLI missing (points at `$CLAUDE_BIN` and the install docs), and
   "neither OPENAI_API_KEY nor Ollama is available" for the embeddings
   backend picker.
+
+### Fixed
+
+- **Integration tests now pass on a green CI.** Stripped the PG17-only
+  `\restrict` / `\unrestrict` psql meta-commands from `sql/schema.sql`
+  (psycopg2 in the test fixture executed them as raw SQL and choked
+  with `syntax error at or near "\"`), and rewrote
+  `tests/integration/test_memory_query.py::test_trigram_search_on_content`
+  to rank rows by `similarity()` directly instead of relying on
+  `pg_trgm.similarity_threshold` (default 0.3 was too strict for a short
+  keyword vs full-sentence content).
+
+### Schema
+
+- `scripts/schema.sql` (additive — does not change any column or
+  constraint). Authoritative `pg_dump --schema-only` of the live
+  `claude_memory` database. Useful for fresh-DB bootstrap from anywhere
+  in the repo without needing the GUI to discover what tables it expects.
 
 ## [0.1.0-beta] — 2026-04-18
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "throughline"
-version = "0.1.0b1"
+version = "0.2.0"
 description = "Persistent long-term memory for Claude Code"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Final pre-tag housekeeping. Bumps \`pyproject.toml\` from \`0.1.0b1\` → \`0.2.0\` and promotes the \`[Unreleased]\` CHANGELOG section to \`[0.2.0] — 2026-04-29\`.

Adds entries for the work that landed this cycle:

- **forget primitive** (#5) — cascade-delete with audit (\`scripts/forget.py\`)
- **MCP server** (#3) — \`memory_mcp/\` exposing six stdio tools to Claude Code
- **KG keyword search + CSV/Excel/PDF export** (#6) — render_export_buttons helper, multi-keyword graph filter
- **pg_dump schema.sql + CI fixes** (#4 + #7) — bundled live schema, \\restrict stripped, trigram test rewritten

Corrects the pre-existing \`[Unreleased]\` line that announced **ten** MCP tools — the server that actually shipped exposes **six** (\`search\`, \`recall_entity\`, \`write\`, \`supersede\`, \`forget\`, \`list_projects\`).

After this lands, \`v0.2.0\` is tagged at the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)