### PR TITLE
fix(gui): Scheduler page shows empty-state when tasks.yaml is absent

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -3271,13 +3271,22 @@ elif page == "Scheduler":
     TASKS_YAML = Path.home() / "Library/Application Support/Claude/scheduler/config/tasks.yaml"
     LOGS_DIR = Path.home() / "Library/Application Support/Claude/scheduler/logs"
 
-    try:
-        with open(TASKS_YAML) as f:
-            tasks_cfg = yaml.safe_load(f)
-        tasks = tasks_cfg.get("tasks", [])
-    except Exception as e:
-        st.error(f"tasks.yaml could not be read: {e}")
-        tasks = []
+    tasks: list = []
+    if not TASKS_YAML.exists():
+        st.info(
+            f"Scheduler not configured. The launchd-backed claude-scheduler skill "
+            f"reads `{TASKS_YAML}` to register recurring tasks; that file does "
+            f"not exist on this machine yet, which is fine if you have not "
+            f"installed the skill. To enable scheduling, install the skill or "
+            f"create the file with `tasks: []` and add entries through this page."
+        )
+    else:
+        try:
+            with open(TASKS_YAML) as f:
+                tasks_cfg = yaml.safe_load(f) or {}
+            tasks = tasks_cfg.get("tasks", []) or []
+        except (yaml.YAMLError, OSError, PermissionError) as e:
+            st.error(f"tasks.yaml could not be read: {e}")
 
     try:
         result = subprocess.run(["launchctl", "list"], capture_output=True, text=True, timeout=5)
@@ -3367,6 +3376,7 @@ elif page == "Scheduler":
                         for t in tasks:
                             if t.get("name") == name:
                                 t["enabled"] = False
+                        TASKS_YAML.parent.mkdir(parents=True, exist_ok=True)
                         with open(TASKS_YAML, "w") as f:
                             yaml.safe_dump({"tasks": tasks}, f, allow_unicode=True)
                         st.rerun()
@@ -3375,6 +3385,7 @@ elif page == "Scheduler":
                         for t in tasks:
                             if t.get("name") == name:
                                 t["enabled"] = True
+                        TASKS_YAML.parent.mkdir(parents=True, exist_ok=True)
                         with open(TASKS_YAML, "w") as f:
                             yaml.safe_dump({"tasks": tasks}, f, allow_unicode=True)
                         st.rerun()


### PR DESCRIPTION
## Summary

If the optional claude-scheduler skill is not installed, the GUI's **Scheduler** page hits \`FileNotFoundError\` on \`~/Library/Application Support/Claude/scheduler/config/tasks.yaml\` and renders a red banner saying *\"tasks.yaml could not be read\"*. That's correct as a hard failure but wrong as the default state — the file is simply absent, which is the expected condition for anyone who hasn't installed that skill.

## Fix

Split the two cases:

- **File does not exist** → friendly \`st.info\` that explains what the Scheduler page is, where the config lives, and how to enable it.
- **File exists but reads or parses badly** → keep \`st.error\`, narrowed to \`(yaml.YAMLError, OSError, PermissionError)\` so unexpected exceptions still surface.

Also harden the **Pause** / **Enable** buttons that write the YAML back: ensure the parent directory exists first, so toggling on a fresh-config machine doesn't fail with \`FileNotFoundError\` on the directory itself (\`Library/Application Support/Claude/scheduler/config/\`).

## Diff

\`\`\`
gui/app.py | 25 ++++++++++++++++++-------
1 file changed, 18 insertions(+), 7 deletions(-)
\`\`\`

## Test plan

- [ ] Open the GUI on a fresh machine without the claude-scheduler skill — Scheduler page shows blue info instead of red error.
- [ ] Open the GUI with a malformed \`tasks.yaml\` — still shows the red error (regression check).
- [ ] On a fresh machine, click **Enable** on a task that gets added later — config file + parent dir get created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)