### PR TITLE
feat: observability + eval-offline (status, memory.stats, eval --offline-stub, GUI Memory Health)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,41 @@ jobs:
           psql -h localhost -U postgres -c "CREATE DATABASE claude_memory;"
           psql -h localhost -U postgres -d claude_memory -f sql/schema.sql
 
+  eval-smoke:
+    name: Eval harness + status (no DB, no API)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+          pip install -e .
+      - name: throughline status --json (DB-unreachable, must still parse)
+        env:
+          PGHOST: 127.0.0.1
+          PGPORT: "1"
+          PGUSER: nobody
+          PGCONNECT_TIMEOUT: "1"
+        run: |
+          set -e
+          python3 -m throughline status --json --pretty | tee /tmp/status.json
+          python3 -c "import json,sys; d=json.load(open('/tmp/status.json'));\
+            assert d['db_reachable'] is False, d;\
+            assert 'table_row_counts' in d;\
+            assert 'chunks_by_category' in d;\
+            print('status payload shape OK')"
+      - name: evals --dry-run (parses 30 questions, no DB, no LLM)
+        run: python3 evals/run_eval.py --dry-run
+      - name: evals --offline-stub (deterministic, no DB, no LLM)
+        run: |
+          python3 evals/run_eval.py --offline-stub --report /tmp/eval_smoke.md
+          test -s /tmp/eval_smoke.md
+          grep -q "with-memory recall" /tmp/eval_smoke.md
+
   markdown-lint:
     name: Markdown links and formatting
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ High-level data flow:
 5. **Reflection pass** merges duplicates, supersedes outdated decisions, logs every action.
 6. **Consumers** (GUI, skill, hooks, CLI) read from the same schema.
 
-A full deep-dive lives in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+A full deep-dive lives in [`docs/architecture.md`](docs/architecture.md).
 
 ---
 
@@ -501,7 +501,7 @@ Eleven tables, three enum types, one view, and HNSW + GIN + trigram indexes.
 | `memory_reflections` | Audit log of dedup, consolidation, and contradiction events |
 | `ingestion_log` | SHA-256 hashes of every ingested file (dedup) |
 
-Full DDL in [`sql/schema.sql`](sql/schema.sql). Conceptual model in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+Full DDL in [`sql/schema.sql`](sql/schema.sql). Conceptual model in [`docs/architecture.md`](docs/architecture.md).
 
 ### Memory categories
 
@@ -649,7 +649,7 @@ embeddings. Full methodology and reproduction steps in
 
 ## Roadmap
 
-- [x] MCP (Model Context Protocol) server — shipped in v0.1.0, see [`mcp/`](mcp/)
+- [x] MCP (Model Context Protocol) server — shipped in v0.1.0, see [`memory_mcp/`](memory_mcp/)
 - [x] Linux scheduler support via `systemd/` timers — shipped in v0.1.0
 - [x] PII / secret-redaction pass before extraction (API keys, tokens,
       emails, home-directory paths); default on, see

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -54,15 +54,21 @@ for sub in ("scripts", "gui", str(_REPO)):
     if p not in sys.path:
         sys.path.insert(0, p)
 
-try:
-    from memory_mcp.server import search as memory_search  # type: ignore
-except Exception as e:
-    print(
-        f"[eval] could not import memory_mcp.server.search ({e}). "
-        "Run `pip install -e .` from the repo root and try again.",
-        file=sys.stderr,
-    )
-    raise
+# memory_search is imported lazily inside retrieve(): the harness must be
+# usable in --dry-run / --offline-stub modes on a CI runner that has no DB,
+# no Postgres client, and no `mcp` SDK installed. Importing at module level
+# fights every one of those.
+memory_search = None  # type: ignore[assignment]
+
+
+def _load_memory_search():
+    """Import memory_mcp.server.search only when really needed."""
+    global memory_search
+    if memory_search is not None:
+        return memory_search
+    from memory_mcp.server import search as _search  # type: ignore
+    memory_search = _search
+    return memory_search
 
 
 @dataclass
@@ -118,13 +124,31 @@ def call_claude(prompt: str, *, model: str = "sonnet") -> str:
 
 # ── Retrieval ────────────────────────────────────────────────────────────────
 def retrieve(query: str, *, project: str | None, top_k: int) -> list[dict]:
-    """Call memory.search the same way the MCP server does at runtime."""
-    return memory_search(
-        query=query,
-        scope=["memory", "messages"],
-        project=project if project else "",
-        limit=top_k,
-    )
+    """Call memory.search the same way the MCP server does at runtime.
+
+    Best-effort: returns ``[]`` if memory_mcp / Postgres / pgvector are
+    unavailable, so ``--offline-stub`` and ``--dry-run`` callers can keep
+    going. The retrieval *failure* is interesting in CI smoke tests
+    (proves the runner doesn't crash), and a real eval run would notice
+    immediately because every question would miss.
+    """
+    try:
+        search_fn = _load_memory_search()
+    except Exception as e:
+        print(f"[eval] retrieval skipped — memory_search unavailable: {e}",
+              file=sys.stderr)
+        return []
+    try:
+        return search_fn(
+            query=query,
+            scope=["memory", "messages"],
+            project=project if project else "",
+            limit=top_k,
+        )
+    except Exception as e:
+        print(f"[eval] retrieval skipped — backend error: {e}",
+              file=sys.stderr)
+        return []
 
 
 def format_context(rows: list[dict]) -> str:
@@ -173,8 +197,23 @@ def load_questions(path: Path) -> list[Question]:
     return out
 
 
-def run_one(q: Question, *, top_k: int, dry_run: bool) -> tuple[Result, Result]:
-    rows = retrieve(q.question, project=q.scope_project, top_k=top_k)
+def _stub_answer(q: Question, *, with_memory: bool) -> str:
+    """Deterministic offline pretend-LLM.
+
+    The with-memory condition emits the first expected_substring (so
+    grade() hits) — pretending memory let it answer. The cold condition
+    emits a fixed "I do not know" so it misses. Lets CI prove that the
+    grader, retrieval glue, and reporting all work without network.
+    """
+    if with_memory and q.expected_substrings:
+        return f"[offline-stub] {q.expected_substrings[0]}"
+    return "[offline-stub] I do not know."
+
+
+def run_one(q: Question, *, top_k: int, dry_run: bool, offline_stub: bool) -> tuple[Result, Result]:
+    rows: list[dict] = []
+    if not dry_run:
+        rows = retrieve(q.question, project=q.scope_project, top_k=top_k)
     retrieved_ids = [int(r["source_id"]) for r in rows if r.get("source_id") is not None]
     ctx = format_context(rows)
 
@@ -190,14 +229,18 @@ def run_one(q: Question, *, top_k: int, dry_run: bool) -> tuple[Result, Result]:
     )
 
     if dry_run:
-        print(f"[{q.id}] would retrieve {len(rows)} chunks; would prompt twice.")
+        print(f"[{q.id}] would retrieve top-{top_k}; would prompt twice (dry-run).")
         return (
             Result(qid=q.id, condition="with-memory", answer="(dry-run)", retrieved_ids=retrieved_ids),
             Result(qid=q.id, condition="cold", answer="(dry-run)"),
         )
 
-    with_ans = call_claude(with_prompt)
-    cold_ans = call_claude(cold_prompt)
+    if offline_stub:
+        with_ans = _stub_answer(q, with_memory=True)
+        cold_ans = _stub_answer(q, with_memory=False)
+    else:
+        with_ans = call_claude(with_prompt)
+        cold_ans = call_claude(cold_prompt)
 
     with_hit, with_match = grade(with_ans, q.expected_substrings)
     cold_hit, cold_match = grade(cold_ans, q.expected_substrings)
@@ -251,19 +294,40 @@ def main() -> int:
     ap.add_argument("--report", type=Path, default=_HERE / "last_run.md")
     ap.add_argument("--top-k", type=int, default=5)
     ap.add_argument("--dry-run", action="store_true",
-                    help="Retrieve only — do not call any LLM.")
+                    help=("Parse questions, do not retrieve, do not call any "
+                          "LLM. Exits 0 if the file parses. Safe in CI "
+                          "without DB or API keys."))
+    ap.add_argument("--offline-stub", action="store_true",
+                    help=("Use a deterministic pretend-LLM that always emits "
+                          "the first expected substring in the with-memory "
+                          "condition and 'I do not know.' in the cold "
+                          "condition. Smoke-tests the harness end-to-end "
+                          "without spending tokens or needing API keys."))
     args = ap.parse_args()
+
+    if args.dry_run and args.offline_stub:
+        print("[eval] --dry-run and --offline-stub are mutually exclusive.",
+              file=sys.stderr)
+        return 2
 
     qs = load_questions(args.questions)
     if not qs:
         print(f"[eval] no questions loaded from {args.questions}", file=sys.stderr)
         return 2
 
-    print(f"[eval] {len(qs)} question(s); top-k={args.top_k}; dry_run={args.dry_run}")
+    print(
+        f"[eval] {len(qs)} question(s); top-k={args.top_k}; "
+        f"dry_run={args.dry_run}; offline_stub={args.offline_stub}"
+    )
     pairs: list[tuple[Result, Result]] = []
     for q in qs:
         try:
-            pair = run_one(q, top_k=args.top_k, dry_run=args.dry_run)
+            pair = run_one(
+                q,
+                top_k=args.top_k,
+                dry_run=args.dry_run,
+                offline_stub=args.offline_stub,
+            )
         except Exception as e:
             print(f"[eval] {q.id}: failed — {e}", file=sys.stderr)
             pair = (
@@ -275,9 +339,11 @@ def main() -> int:
         if not args.dry_run:
             print(f"  {q.id}: with={'✓' if w.hit else '✗'}  cold={'✓' if c.hit else '✗'}")
 
-    if not args.dry_run:
-        write_report(args.report, qs, pairs)
-        print(f"[eval] wrote {args.report}")
+    if args.dry_run:
+        return 0
+
+    write_report(args.report, qs, pairs)
+    print(f"[eval] wrote {args.report}")
 
     return 0
 

--- a/gui/app.py
+++ b/gui/app.py
@@ -1483,6 +1483,31 @@ elif page == "Dashboard":
     c3.metric("Memory chunks", f"{int(r['mem']):,}")
     c4.metric("Skills",        f"{int(r['sk']):,}")
 
+    # ── Memory Health card ────────────────────────────────────────────────
+    # Sourced from throughline.status.collect_status so the same payload
+    # backs the CLI subcommand, the memory.stats MCP tool, and this card.
+    # Avoids three drifting copies of "what does healthy memory look like?".
+    try:
+        from throughline.status import collect_status as _collect_status
+        _health = _collect_status(conn=_live_conn())
+    except Exception:
+        _health = None
+
+    if _health and _health.get("db_reachable"):
+        st.markdown("<div style='height:1.0rem;'></div>", unsafe_allow_html=True)
+        st.markdown('<div class="kai-section-label">Memory health</div>',
+                    unsafe_allow_html=True)
+        h1, h2, h3, h4 = st.columns(4)
+        h1.metric("Embedding coverage",
+                  f"{_health.get('embedding_coverage_pct', 0.0):.1f}%")
+        h2.metric("Projects", f"{_health.get('projects_count', 0):,}")
+        h3.metric("Contradictions",
+                  f"{_health.get('contradictions_outstanding', 0):,}")
+        last_refl = _health.get("last_reflection_at") or "—"
+        if last_refl != "—":
+            last_refl = fmt_dt(last_refl, compact=True)
+        h4.metric("Last reflection", last_refl)
+
     st.markdown("<div style='height:1.5rem;'></div>", unsafe_allow_html=True)
 
     left, right = st.columns([3, 2])

--- a/memory_mcp/server.py
+++ b/memory_mcp/server.py
@@ -474,6 +474,34 @@ def preload_summary() -> dict:
     return d
 
 
+@mcp.tool()
+def stats() -> dict:
+    """Aggregate health snapshot of the memory DB.
+
+    Returns the same payload as ``throughline status --json``:
+    table row counts, memory chunks total + by category, embedding
+    coverage percent, last-extraction / last-reflection timestamps,
+    outstanding contradictions, and project count. Use this before a
+    long retrieval session to know what's actually in memory, or before
+    a reflection pass to see if there's a backlog.
+    """
+    from throughline.status import collect_status
+    conn = connect()
+    try:
+        payload = collect_status(conn=conn)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+    _log(
+        "memory.stats",
+        chunks=payload.get("chunks_total", 0),
+        coverage=payload.get("embedding_coverage_pct", 0.0),
+    )
+    return payload
+
+
 def main() -> None:
     mcp.run()
 

--- a/tests/test_eval_offline.py
+++ b/tests/test_eval_offline.py
@@ -1,0 +1,94 @@
+"""Tests for the offline / dry-run paths of the eval harness.
+
+CI cannot stand up Postgres or pay for tokens; these tests prove the
+harness is still useful in that environment.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parent.parent
+EVAL_PY = REPO / "evals" / "run_eval.py"
+QUESTIONS = REPO / "evals" / "questions.jsonl"
+
+
+# Force PG to look unreachable so any retrieval attempt fails fast and
+# proves the harness doesn't need a DB in these modes.
+NO_DB_ENV = {
+    "PGHOST": "127.0.0.1",
+    "PGPORT": "1",
+    "PGUSER": "nobody",
+    "PGCONNECT_TIMEOUT": "1",
+    "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+}
+
+
+def _run_eval(*args: str, timeout: int = 30) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(EVAL_PY), *args],
+        cwd=REPO,
+        capture_output=True, text=True,
+        env={**NO_DB_ENV, "PYTHONPATH": str(REPO)},
+        timeout=timeout,
+    )
+
+
+def test_dry_run_parses_30_questions_and_exits_zero():
+    proc = _run_eval("--dry-run", "--questions", str(QUESTIONS))
+    assert proc.returncode == 0, proc.stderr
+    # All 30 questions emit a "would retrieve" line in dry-run.
+    assert proc.stdout.count("would retrieve") == 30
+
+
+def test_dry_run_does_not_write_a_report(tmp_path):
+    report = tmp_path / "report.md"
+    proc = _run_eval("--dry-run", "--report", str(report),
+                     "--questions", str(QUESTIONS))
+    assert proc.returncode == 0, proc.stderr
+    assert not report.exists(), "dry-run must not write a report"
+
+
+def test_offline_stub_writes_report_and_perfect_with_memory(tmp_path):
+    report = tmp_path / "report.md"
+    proc = _run_eval("--offline-stub", "--report", str(report),
+                     "--questions", str(QUESTIONS), timeout=60)
+    assert proc.returncode == 0, proc.stderr
+    body = report.read_text(encoding="utf-8")
+    assert "with-memory recall" in body
+    assert "30/30" in body, "stub answers always hit"
+    assert "0/30" in body, "stub cold answers always miss"
+    # Per-question table renders.
+    assert "| ID | Category" in body
+
+
+def test_dry_run_and_offline_stub_are_mutually_exclusive():
+    proc = _run_eval("--dry-run", "--offline-stub")
+    assert proc.returncode == 2
+    assert "mutually exclusive" in proc.stderr
+
+
+def test_offline_stub_handles_missing_expected_substrings(tmp_path, monkeypatch):
+    """If a question has an empty expected_substrings list, stub falls
+    back to the I-do-not-know answer in both conditions — the harness
+    must not crash on edge-case questions."""
+    qfile = tmp_path / "edge.jsonl"
+    qfile.write_text(
+        '{"id":"E01","category":"control",'
+        '"question":"will Claude know this?","expected_substrings":[]}\n',
+        encoding="utf-8",
+    )
+    report = tmp_path / "edge.md"
+    proc = _run_eval(
+        "--offline-stub",
+        "--questions", str(qfile),
+        "--report", str(report),
+    )
+    assert proc.returncode == 0, proc.stderr
+    body = report.read_text(encoding="utf-8")
+    assert "0/1" in body  # neither condition can hit on empty substrings

--- a/tests/test_mcp_stats.py
+++ b/tests/test_mcp_stats.py
@@ -1,0 +1,55 @@
+"""Tests for the ``memory.stats`` MCP tool.
+
+We don't go through the FastMCP transport here — we exercise the wrapped
+function directly, which is what ``tool_to_call(...)`` resolves to. The
+real protocol-level test would need an MCP client; the value of this
+test is that the parent re-uses ``throughline.status.collect_status`` so
+the payload contract is enforced in one place.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def test_memory_stats_tool_is_registered():
+    from memory_mcp import server
+    # FastMCP wraps the function; in either form, the symbol exists.
+    assert hasattr(server, "stats"), \
+        "memory_mcp.server.stats must exist for the MCP tool wiring"
+
+
+def test_memory_stats_returns_payload_when_db_unreachable(monkeypatch):
+    """Connect failure must surface as ``db_reachable=False`` rather than
+    a 500-style error from the MCP transport."""
+    from memory_mcp import server
+
+    monkeypatch.setattr(server, "connect", lambda: None)
+    # collect_status's fallback path will fire because conn is None and
+    # then it tries to open one itself — also force that to fail.
+    from throughline import status as st
+    monkeypatch.setattr(st, "_connect", lambda: None)
+
+    payload = server.stats()
+    assert isinstance(payload, dict)
+    assert payload.get("db_reachable") is False
+    assert "table_row_counts" in payload
+    assert "chunks_by_category" in payload
+
+
+def test_memory_stats_payload_has_stable_keys(monkeypatch):
+    from memory_mcp import server
+    from throughline import status as st
+
+    monkeypatch.setattr(server, "connect", lambda: None)
+    monkeypatch.setattr(st, "_connect", lambda: None)
+
+    payload = server.stats()
+    expected = {
+        "db_reachable", "captured_at", "schema_version", "error",
+        "table_row_counts", "chunks_total", "chunks_by_category",
+        "embedding_coverage_pct", "last_extraction_at",
+        "last_reflection_at", "contradictions_outstanding",
+        "projects_count", "version",
+    }
+    missing = expected - set(payload)
+    assert not missing, f"memory.stats payload missing keys: {missing}"

--- a/tests/test_mcp_stats.py
+++ b/tests/test_mcp_stats.py
@@ -10,6 +10,12 @@ from __future__ import annotations
 
 import pytest
 
+# The ``mcp`` SDK is not a hard dependency of the project — only the MCP
+# server entry point needs it. Skip these tests when it isn't installed,
+# so the unit-tests CI job (which installs only requirements.txt +
+# requirements-dev.txt) stays green.
+pytest.importorskip("mcp")
+
 
 def test_memory_stats_tool_is_registered():
     from memory_mcp import server

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,268 @@
+"""Tests for ``throughline.status`` and the ``throughline status`` CLI.
+
+All DB-free: a fake connection / cursor stands in for psycopg2 so we can
+exercise the SQL paths without standing up Postgres. The shape and field
+names of the payload are part of the contract — three other surfaces
+(CLI, MCP tool, GUI card) consume it.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REQUIRED_KEYS = {
+    "db_reachable",
+    "captured_at",
+    "schema_version",
+    "error",
+    "table_row_counts",
+    "chunks_total",
+    "chunks_by_category",
+    "embedding_coverage_pct",
+    "last_extraction_at",
+    "last_reflection_at",
+    "contradictions_outstanding",
+    "projects_count",
+    "version",
+}
+
+
+# ── Fakes ────────────────────────────────────────────────────────────────────
+class _FakeCursor:
+    """Minimal cursor that returns canned answers per SQL pattern."""
+
+    def __init__(
+        self,
+        *,
+        counts: dict[str, int],
+        chunks_total: int = 100,
+        embedded: int = 80,
+        contradictions: int = 3,
+        projects: int = 4,
+        last_reflection: datetime | None = None,
+        last_extraction: datetime | None = None,
+        schema_version_table_exists: bool = False,
+        schema_version_value: str | None = None,
+    ):
+        self.counts = counts
+        self.chunks_total = chunks_total
+        self.embedded = embedded
+        self.contradictions = contradictions
+        self.projects = projects
+        self.last_reflection = last_reflection
+        self.last_extraction = last_extraction
+        self.schema_version_table_exists = schema_version_table_exists
+        self.schema_version_value = schema_version_value
+        self._buf: list[tuple] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, sql: str, params=None):
+        s = " ".join(sql.split())
+        if "to_regclass('public.schema_migrations')" in s:
+            self._buf = [(self.schema_version_table_exists,)]
+        elif "FROM public.schema_migrations" in s:
+            self._buf = [(self.schema_version_value,)] if self.schema_version_value else []
+        elif "WHERE reflection_type = 'contradiction'" in s:
+            # Must come BEFORE the generic count-from-public branch — both
+            # match this query otherwise.
+            self._buf = [(self.contradictions,)]
+        elif s.startswith("SELECT count(*) FROM public.") and "WHERE" not in s:
+            tbl = s.split("FROM public.")[1].split()[0]
+            self._buf = [(self.counts.get(tbl, 0),)]
+        elif "FROM public.memory_chunks WHERE status = 'active' GROUP BY category" in s:
+            self._buf = [("decision", 5), ("pattern", 7), ("workflow", 3)]
+        elif "(SELECT count(*) FROM public.memory_chunks) AS chunks" in s:
+            self._buf = [(self.chunks_total, self.embedded)]
+        elif "max(created_at) FROM public.memory_chunks" in s:
+            self._buf = [(self.last_extraction,)]
+        elif "max(created_at) FROM public.memory_reflections" in s:
+            self._buf = [(self.last_reflection,)]
+        elif "DISTINCT project_name" in s:
+            self._buf = [(self.projects,)]
+        else:
+            self._buf = []
+
+    def fetchone(self):
+        return self._buf[0] if self._buf else None
+
+    def fetchall(self):
+        return list(self._buf)
+
+
+class _FakeConn:
+    def __init__(self, cursor: _FakeCursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+    def close(self):  # pragma: no cover - never asserted
+        pass
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+def test_collect_status_db_unreachable_returns_safe_payload(monkeypatch):
+    from throughline import status as st
+
+    monkeypatch.setattr(st, "_connect", lambda: None)
+    payload = st.collect_status()
+
+    assert payload["db_reachable"] is False
+    assert payload["error"]
+    assert REQUIRED_KEYS <= set(payload), f"missing keys: {REQUIRED_KEYS - set(payload)}"
+    # Even unreachable, the empty payload must be JSON-serialisable.
+    json.dumps(payload)
+
+
+def test_collect_status_with_fake_conn_populates_fields():
+    from throughline import status as st
+
+    last_refl = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+    cur = _FakeCursor(
+        counts={
+            "conversations": 10,
+            "messages": 50,
+            "memory_chunks": 100,
+            "embeddings": 80,
+            "memory_reflections": 5,
+            "skills": 20,
+            "prompts": 8,
+            "projects": 3,
+            "entities": 40,
+            "entity_mentions": 60,
+            "relationships": 30,
+        },
+        chunks_total=100,
+        embedded=80,
+        contradictions=2,
+        projects=3,
+        last_reflection=last_refl,
+    )
+    conn = _FakeConn(cur)
+    payload = st.collect_status(conn=conn)
+
+    assert payload["db_reachable"] is True
+    assert payload["table_row_counts"]["memory_chunks"] == 100
+    assert payload["chunks_total"] == 100
+    assert payload["embedding_coverage_pct"] == 80.0
+    assert payload["chunks_by_category"]["decision"] == 5
+    # Categories not returned by GROUP BY must still be present at zero.
+    assert payload["chunks_by_category"]["insight"] == 0
+    assert payload["last_reflection_at"] == last_refl.isoformat()
+    assert payload["contradictions_outstanding"] == 2
+    assert payload["projects_count"] == 3
+
+
+def test_collect_status_handles_zero_chunks_without_dividing():
+    from throughline import status as st
+
+    cur = _FakeCursor(
+        counts={
+            t: 0
+            for t in (
+                "conversations",
+                "messages",
+                "memory_chunks",
+                "embeddings",
+                "memory_reflections",
+                "skills",
+                "prompts",
+                "projects",
+                "entities",
+                "entity_mentions",
+                "relationships",
+            )
+        },
+        chunks_total=0,
+        embedded=0,
+    )
+    payload = st.collect_status(conn=_FakeConn(cur))
+    assert payload["embedding_coverage_pct"] == 0.0
+
+
+def test_format_human_renders_unreachable():
+    from throughline.status import _empty_payload, format_human  # type: ignore
+
+    out = format_human(_empty_payload(error="boom"))
+    assert "unreachable" in out.lower()
+    assert "boom" in out
+
+
+def test_format_human_renders_reachable_payload():
+    from throughline.status import format_human
+
+    payload = {
+        "db_reachable": True,
+        "captured_at": "2026-05-10T00:00:00+00:00",
+        "schema_version": None,
+        "error": None,
+        "table_row_counts": {"memory_chunks": 42},
+        "chunks_total": 42,
+        "chunks_by_category": {"decision": 10, "pattern": 32},
+        "embedding_coverage_pct": 75.0,
+        "last_extraction_at": None,
+        "last_reflection_at": None,
+        "contradictions_outstanding": 1,
+        "projects_count": 2,
+        "version": "0.2.0",
+    }
+    out = format_human(payload)
+    assert "reachable" in out
+    assert "42" in out
+    assert "75.00" in out
+    assert "decision" in out
+
+
+def test_cli_status_json_contract(tmp_path):
+    """``python -m throughline status --json`` must emit valid JSON whose
+    shape matches REQUIRED_KEYS, even with no DB reachable. CI relies on
+    this."""
+    env = {
+        "PGHOST": "127.0.0.1",
+        "PGPORT": "1",
+        "PGUSER": "nobody",
+        "PGCONNECT_TIMEOUT": "1",
+        # Pass through PATH so subprocess can find python on macOS.
+        "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+    }
+    proc = subprocess.run(
+        [sys.executable, "-m", "throughline", "status", "--json"],
+        cwd=Path(__file__).resolve().parent.parent,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert REQUIRED_KEYS <= set(payload), f"missing keys: {REQUIRED_KEYS - set(payload)}"
+
+
+def test_cli_status_pretty_indents_output(tmp_path):
+    env = {
+        "PGHOST": "127.0.0.1",
+        "PGPORT": "1",
+        "PGUSER": "nobody",
+        "PGCONNECT_TIMEOUT": "1",
+        "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+    }
+    proc = subprocess.run(
+        [sys.executable, "-m", "throughline", "status", "--json", "--pretty"],
+        cwd=Path(__file__).resolve().parent.parent,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    # Pretty-printed has at least one indented line.
+    assert "\n  " in proc.stdout

--- a/throughline/cli.py
+++ b/throughline/cli.py
@@ -15,19 +15,18 @@ Run ``throughline --help`` for the full list of commands.
 from __future__ import annotations
 
 import argparse
-import os
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from throughline import __version__
 from throughline.config import repo_root
 
-
 # --------------------------------------------------------------------------- #
 # Helpers                                                                     #
 # --------------------------------------------------------------------------- #
+
 
 def _ensure_scripts_on_path() -> Path:
     """Add ``<repo>/scripts`` to ``sys.path`` so scripts are importable.
@@ -100,6 +99,7 @@ def _run_shell_script(script_name: str, args: list[str]) -> int:
 # --------------------------------------------------------------------------- #
 # Subcommand handlers                                                         #
 # --------------------------------------------------------------------------- #
+
 
 def cmd_ingest(args: argparse.Namespace) -> int:
     """Ingest Claude Code JSONL sessions (or Windsurf plans with --windsurf)."""
@@ -177,8 +177,7 @@ def cmd_gui(args: argparse.Namespace) -> int:
         return subprocess.call(cmd)
     except FileNotFoundError:
         print(
-            "ERROR: `streamlit` not installed. Install with: "
-            "pip install -e . (core deps include Streamlit).",
+            "ERROR: `streamlit` not installed. Install with: " "pip install -e . (core deps include Streamlit).",
             file=sys.stderr,
         )
         return 2
@@ -200,9 +199,30 @@ def cmd_version(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_status(args: argparse.Namespace) -> int:
+    """Print a health snapshot of the memory DB.
+
+    Plain text by default; ``--json`` emits a JSON object on stdout.
+    Exit code is 0 if the DB was reachable, 2 if not — except in
+    ``--json`` mode, where exit is always 0 so machine consumers can
+    parse the payload (which carries ``db_reachable`` itself).
+    """
+    import json
+
+    from throughline.status import collect_status, format_human
+
+    payload = collect_status()
+    if args.json:
+        print(json.dumps(payload, indent=2 if args.pretty else None, sort_keys=True))
+        return 0
+    print(format_human(payload))
+    return 0 if payload.get("db_reachable") else 2
+
+
 # --------------------------------------------------------------------------- #
 # Parser construction                                                         #
 # --------------------------------------------------------------------------- #
+
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -279,12 +299,16 @@ def build_parser() -> argparse.ArgumentParser:
             "Use --backend=ollama for a fully local setup."
         ),
     )
-    p.add_argument("--backend", choices=["openai", "ollama", "auto"], default="auto",
-                   help="Embeddings backend. Default: auto (OpenAI if key set, else Ollama).")
-    p.add_argument("--limit", type=int, default=None,
-                   help="Only process N pending entries (useful for smoke tests).")
-    p.add_argument("--only", choices=["memory_chunk", "message", "both"], default=None,
-                   help="Restrict to a single source type.")
+    p.add_argument(
+        "--backend",
+        choices=["openai", "ollama", "auto"],
+        default="auto",
+        help="Embeddings backend. Default: auto (OpenAI if key set, else Ollama).",
+    )
+    p.add_argument("--limit", type=int, default=None, help="Only process N pending entries (useful for smoke tests).")
+    p.add_argument(
+        "--only", choices=["memory_chunk", "message", "both"], default=None, help="Restrict to a single source type."
+    )
     p.set_defaults(func=cmd_embed)
 
     # search
@@ -294,8 +318,12 @@ def build_parser() -> argparse.ArgumentParser:
         description="Cosine-distance search via pgvector. Requires prior `throughline embed`.",
     )
     p.add_argument("query", help="Free-form search string.")
-    p.add_argument("--backend", choices=["openai", "ollama", "auto"], default="auto",
-                   help="Embeddings backend. Must match how embeddings were generated.")
+    p.add_argument(
+        "--backend",
+        choices=["openai", "ollama", "auto"],
+        default="auto",
+        help="Embeddings backend. Must match how embeddings were generated.",
+    )
     p.add_argument("--limit", type=int, default=None, help="Max number of results to return.")
     p.set_defaults(func=cmd_search)
 
@@ -304,12 +332,14 @@ def build_parser() -> argparse.ArgumentParser:
         "reflect",
         help="Run the self-reflecting memory engine (dedup / contradictions / stale / consolidate).",
     )
-    p.add_argument("--mode", choices=["dedup", "contradictions", "stale", "consolidate"],
-                   default=None, help="Run a single mode instead of all four.")
-    p.add_argument("--dry-run", action="store_true",
-                   help="Don't write any changes to the database.")
-    p.add_argument("--limit", type=int, default=None,
-                   help="Cap on pair-comparisons per mode.")
+    p.add_argument(
+        "--mode",
+        choices=["dedup", "contradictions", "stale", "consolidate"],
+        default=None,
+        help="Run a single mode instead of all four.",
+    )
+    p.add_argument("--dry-run", action="store_true", help="Don't write any changes to the database.")
+    p.add_argument("--limit", type=int, default=None, help="Cap on pair-comparisons per mode.")
     p.set_defaults(func=cmd_reflect)
 
     # gui
@@ -317,8 +347,7 @@ def build_parser() -> argparse.ArgumentParser:
         "gui",
         help="Start the Streamlit GUI (requires `streamlit` on PATH).",
     )
-    p.add_argument("--port", type=int, default=None,
-                   help="Port for the Streamlit server (default: 8501).")
+    p.add_argument("--port", type=int, default=None, help="Port for the Streamlit server (default: 8501).")
     p.set_defaults(func=cmd_gui)
 
     # install-hooks
@@ -341,6 +370,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="Print the installed Throughline version and exit.",
     )
     p.set_defaults(func=cmd_version)
+
+    # status
+    p = sub.add_parser(
+        "status",
+        help="Health snapshot of the memory DB (table counts, embedding coverage, …).",
+        description=(
+            "Reports DB reachability, schema version, table row counts, "
+            "memory-chunk totals by category, embedding coverage, and the "
+            "timestamps of the most recent extraction and reflection runs. "
+            "Use --json for a machine-readable payload."
+        ),
+    )
+    p.add_argument("--json", action="store_true", help="Emit a JSON object on stdout instead of human text.")
+    p.add_argument("--pretty", action="store_true", help="With --json, indent the output (default: single line).")
+    p.set_defaults(func=cmd_status)
 
     return parser
 

--- a/throughline/status.py
+++ b/throughline/status.py
@@ -1,0 +1,299 @@
+"""Health / inventory snapshot for a Throughline DB.
+
+One source of truth for three surfaces:
+
+  * ``throughline status`` CLI subcommand (human + ``--json``)
+  * ``memory.stats`` MCP tool
+  * Streamlit GUI Memory Health card
+
+Each surface formats the same dict; nobody re-implements the SQL.
+
+Design notes
+------------
+
+The function never raises on a missing/unreachable DB. It returns a dict
+with ``db_reachable=False`` and an ``error`` key, so the GUI and the MCP
+tool can render a useful message instead of crashing. Tests rely on this
+behaviour to validate the JSON shape without standing up Postgres.
+
+Schema-version reporting is best-effort: if a ``schema_migrations`` table
+does not exist the field is set to ``None``, not an error — the project
+ships ``sql/schema.sql`` as the authoritative schema and not every install
+has Alembic-style migrations applied.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+# Schema-derived constants — kept in lock-step with sql/schema.sql.
+# Listed explicitly (not auto-discovered) so a missing table is loud.
+_CORE_TABLES: tuple[str, ...] = (
+    "conversations",
+    "messages",
+    "memory_chunks",
+    "embeddings",
+    "memory_reflections",
+    "skills",
+    "prompts",
+    "projects",
+    "entities",
+    "entity_mentions",
+    "relationships",
+)
+
+# Categories declared in the memory_chunks ``category`` enum (sql/schema.sql).
+_CATEGORIES: tuple[str, ...] = (
+    "decision",
+    "pattern",
+    "insight",
+    "preference",
+    "contact",
+    "error_solution",
+    "project_context",
+    "workflow",
+)
+
+
+@dataclass
+class StatusPayload:
+    """Typed wrapper around the snapshot dict.
+
+    The dict form is what every surface (CLI/MCP/GUI) actually consumes —
+    this dataclass exists so test code can construct fixtures without
+    duplicating field names.
+    """
+
+    db_reachable: bool
+    captured_at: str
+    schema_version: str | None = None
+    error: str | None = None
+    table_row_counts: dict[str, int] = field(default_factory=dict)
+    chunks_total: int = 0
+    chunks_by_category: dict[str, int] = field(default_factory=dict)
+    embedding_coverage_pct: float = 0.0
+    last_extraction_at: str | None = None
+    last_reflection_at: str | None = None
+    contradictions_outstanding: int = 0
+    projects_count: int = 0
+    version: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "db_reachable": self.db_reachable,
+            "captured_at": self.captured_at,
+            "schema_version": self.schema_version,
+            "error": self.error,
+            "table_row_counts": dict(self.table_row_counts),
+            "chunks_total": self.chunks_total,
+            "chunks_by_category": dict(self.chunks_by_category),
+            "embedding_coverage_pct": self.embedding_coverage_pct,
+            "last_extraction_at": self.last_extraction_at,
+            "last_reflection_at": self.last_reflection_at,
+            "contradictions_outstanding": self.contradictions_outstanding,
+            "projects_count": self.projects_count,
+            "version": self.version,
+        }
+
+
+def _empty_payload(*, error: str | None = None) -> dict[str, Any]:
+    from throughline import __version__
+
+    return StatusPayload(
+        db_reachable=False,
+        captured_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        error=error,
+        table_row_counts={t: 0 for t in _CORE_TABLES},
+        chunks_by_category={c: 0 for c in _CATEGORIES},
+        version=__version__,
+    ).to_dict()
+
+
+def _connect():
+    """Open a DB connection using libpq env vars. Returns None on failure.
+
+    Lives here (not imported from memory_mcp.db) so this module stays usable
+    in environments where the optional ``mcp`` SDK isn't installed.
+    """
+    try:
+        import psycopg2  # type: ignore
+    except Exception:
+        return None
+    cfg = {
+        "host": os.environ.get("PGHOST", "localhost"),
+        "port": int(os.environ.get("PGPORT", "5432")),
+        "dbname": os.environ.get("PGDATABASE", "claude_memory"),
+        "user": os.environ.get("PGUSER", os.environ.get("USER") or "postgres"),
+        "connect_timeout": int(os.environ.get("PGCONNECT_TIMEOUT", "3")),
+    }
+    pw = os.environ.get("PGPASSWORD")
+    if pw:
+        cfg["password"] = pw
+    try:
+        return psycopg2.connect(**cfg)
+    except Exception:
+        return None
+
+
+def _safe_count(cur, table: str) -> int:
+    try:
+        cur.execute(f"SELECT count(*) FROM public.{table}")
+        row = cur.fetchone()
+        return int(row[0]) if row else 0
+    except Exception:
+        return 0
+
+
+def _schema_version(cur) -> str | None:
+    """Best-effort schema version. Returns None if no migrations table."""
+    try:
+        cur.execute("SELECT to_regclass('public.schema_migrations') IS NOT NULL")
+        row = cur.fetchone()
+        if not row or not row[0]:
+            return None
+        cur.execute("SELECT version FROM public.schema_migrations " "ORDER BY applied_at DESC NULLS LAST LIMIT 1")
+        row = cur.fetchone()
+        return str(row[0]) if row else None
+    except Exception:
+        return None
+
+
+def collect_status(*, conn=None) -> dict[str, Any]:
+    """Return a JSON-safe dict describing the DB.
+
+    If ``conn`` is supplied it is used as-is and not closed (tests pass a
+    mock). If ``conn`` is None we open one ourselves with ``_connect`` and
+    close it on the way out.
+    """
+    from throughline import __version__
+
+    owns_conn = False
+    if conn is None:
+        conn = _connect()
+        owns_conn = True
+        if conn is None:
+            return _empty_payload(error="DB unreachable (psycopg2 missing or connection refused)")
+
+    try:
+        with conn.cursor() as cur:
+            payload = StatusPayload(
+                db_reachable=True,
+                captured_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                version=__version__,
+                table_row_counts={t: _safe_count(cur, t) for t in _CORE_TABLES},
+                chunks_by_category={c: 0 for c in _CATEGORIES},
+            )
+            payload.schema_version = _schema_version(cur)
+            payload.chunks_total = payload.table_row_counts.get("memory_chunks", 0)
+
+            try:
+                cur.execute(
+                    "SELECT category::text, count(*) FROM public.memory_chunks "
+                    "WHERE status = 'active' GROUP BY category"
+                )
+                for cat, n in cur.fetchall():
+                    payload.chunks_by_category[str(cat)] = int(n)
+            except Exception:
+                pass
+
+            try:
+                cur.execute(
+                    """
+                    SELECT
+                        (SELECT count(*) FROM public.memory_chunks) AS chunks,
+                        (SELECT count(*) FROM public.embeddings
+                            WHERE source_type = 'memory_chunk') AS embedded
+                    """
+                )
+                row = cur.fetchone()
+                if row and row[0]:
+                    chunks, embedded = int(row[0]), int(row[1] or 0)
+                    payload.embedding_coverage_pct = round(100.0 * embedded / chunks, 2)
+            except Exception:
+                pass
+
+            try:
+                cur.execute(
+                    "SELECT max(created_at) FROM public.memory_chunks "
+                    "WHERE source_type = 'extraction' OR source_type = 'mcp_write'"
+                )
+                row = cur.fetchone()
+                if row and row[0]:
+                    payload.last_extraction_at = row[0].isoformat()
+            except Exception:
+                pass
+
+            try:
+                cur.execute("SELECT max(created_at) FROM public.memory_reflections")
+                row = cur.fetchone()
+                if row and row[0]:
+                    payload.last_reflection_at = row[0].isoformat()
+            except Exception:
+                pass
+
+            try:
+                cur.execute(
+                    "SELECT count(*) FROM public.memory_reflections "
+                    "WHERE reflection_type = 'contradiction' "
+                    "AND (action_taken IS NULL OR action_taken = 'flagged')"
+                )
+                row = cur.fetchone()
+                payload.contradictions_outstanding = int(row[0]) if row else 0
+            except Exception:
+                pass
+
+            try:
+                cur.execute(
+                    "SELECT count(DISTINCT project_name) FROM public.memory_chunks " "WHERE project_name IS NOT NULL"
+                )
+                row = cur.fetchone()
+                payload.projects_count = int(row[0]) if row else 0
+            except Exception:
+                pass
+
+            return payload.to_dict()
+    finally:
+        if owns_conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+def format_human(payload: dict[str, Any]) -> str:
+    """Pretty-print a status payload for the CLI."""
+    lines: list[str] = []
+    head = "Throughline status"
+    if payload.get("version"):
+        head += f" — v{payload['version']}"
+    lines.append(head)
+    lines.append("=" * len(head))
+    lines.append(f"Captured: {payload.get('captured_at', '?')}")
+    if not payload.get("db_reachable"):
+        lines.append("DB:       unreachable")
+        if payload.get("error"):
+            lines.append(f"Error:    {payload['error']}")
+        return "\n".join(lines)
+
+    lines.append("DB:       reachable")
+    sv = payload.get("schema_version")
+    lines.append(f"Schema:   {sv if sv else '(no schema_migrations table)'}")
+    lines.append("")
+    lines.append("Table row counts:")
+    for t, n in (payload.get("table_row_counts") or {}).items():
+        lines.append(f"  {t:<22} {n:>10,}")
+    lines.append("")
+    lines.append(f"Memory chunks total:        {payload.get('chunks_total', 0):,}")
+    lines.append(f"Embedding coverage:         {payload.get('embedding_coverage_pct', 0.0):.2f}%")
+    lines.append(f"Projects:                   {payload.get('projects_count', 0)}")
+    lines.append(f"Last extraction at:         {payload.get('last_extraction_at') or '—'}")
+    lines.append(f"Last reflection at:         {payload.get('last_reflection_at') or '—'}")
+    lines.append(f"Contradictions outstanding: {payload.get('contradictions_outstanding', 0)}")
+    lines.append("")
+    lines.append("Chunks by category:")
+    for cat, n in (payload.get("chunks_by_category") or {}).items():
+        lines.append(f"  {cat:<22} {n:>10,}")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary

Closes the gap between "the project ships features" and "an operator/agent can tell whether memory is healthy and the eval harness still works." Five small additions, each runnable without Postgres or an API key for the new `--dry-run` / `--offline-stub` paths.

- **`throughline status [--json] [--pretty]`** — DB reachability, schema version (best-effort), per-table row counts, embedding coverage %, last-extraction / last-reflection timestamps, contradictions outstanding, project count. Single `throughline.status.collect_status` helper backs all three surfaces (CLI, MCP, GUI).
- **`memory.stats` MCP tool** — same payload over MCP. Lets agents check what's in memory before deciding to query.
- **Eval harness** — `--dry-run` is now truly DB-free (skips retrieval entirely). New `--offline-stub` mode runs end-to-end with a deterministic pretend-LLM (always 30/30 with-memory vs 0/30 cold), so CI can prove the grader / retrieval glue / report writer work.
- **GUI Memory Health card** on Dashboard — four KPI tiles below the existing 4-column metric row. Hides itself silently when DB is unreachable.
- **CI eval-smoke job** — runs `throughline status --json` against an unreachable PG and asserts payload still parses; runs both eval modes and asserts the report has the headline line. Catches the "fresh fork" regression class.

## What's gained per stakeholder

- *Operator:* a single command (`throughline status --json`) for `docker compose` healthcheck, monitoring scrapes, fresh-clone smoke.
- *Agent (over MCP):* `memory.stats` answers "should I query, or is memory cold?"
- *Anthropic-aligned dogfooding:* the eval harness can run on every PR without needing keys; if retrieval ever rots, CI catches it.
- *Customer:* operator can see embedding coverage and contradiction backlog at a glance on the Dashboard.

## Why this scope, why now

- The README/CHANGELOG explicitly say evals are "scaffolded but not yet run." The harness needed an offline path before any CI gate could be added.
- All five changes share `throughline.status.collect_status` as one source of truth, so fixing this once didn't grow into three subtly-different implementations.
- Strictly additive — no migration, no schema change, no new top-level deps.

## Test plan

- [x] `pytest -q --ignore=tests/integration` — 112 passing (97 existing + 15 new)
- [x] `python3 -m throughline status --json` against live DB — valid payload, `chunks_total > 0`
- [x] `PGHOST=127.0.0.1 PGPORT=1 python3 -m throughline status --json` — valid payload, `db_reachable=false`, exit 0
- [x] `evals/run_eval.py --dry-run` — no DB, no API key, exits 0
- [x] `evals/run_eval.py --offline-stub --report …` — writes report with `with-memory recall: 30/30` and `cold recall: 0/30`
- [x] `python3 -c "import gui.app"` — clean (Streamlit ScriptRunContext warnings expected outside `streamlit run`)
- [x] `streamlit run gui/app.py` — boots, `/_stcore/health` returns ok
- [x] Negative control: removing `throughline/status.py` makes `throughline status` fail with `ModuleNotFoundError` — the verifier is real.

## Notes

- The `--offline-stub` run prints retrieval-failure lines on stderr when DB is unreachable. That is intentional and correct — the harness reports retrieval issues and continues with the stub answer; CI only asserts on report contents.
- The GUI Memory Health card guards on `db_reachable` so the existing demo deploys (intermittent or no DB) keep working.
- A duplicate PR exists at https://github.com/mkupermann/claude-memory-db/pull/5 because both remotes are configured locally; close whichever you don't merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)