### PR TITLE
docs: README + CHANGELOG + evals/README — observability + eval-offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`throughline status` subcommand.** Health snapshot of the memory DB:
+  reachability, schema version (best-effort), table row counts,
+  memory-chunk totals + by category, embedding coverage %, last-extraction
+  / last-reflection timestamps, contradictions outstanding, project
+  count. Plain text by default; `--json [--pretty]` for machine consumers
+  (Docker healthcheck, monitoring scrapes, fresh-clone smoke). When the DB
+  is unreachable the JSON payload still parses, with `db_reachable=false`.
+- **`memory.stats` MCP tool.** Exposes the same payload as
+  `throughline status --json` over MCP, so an agent can ask "what's
+  actually in memory?" before a long retrieval session or a reflection
+  pass. One helper (`throughline.status.collect_status`) backs the CLI,
+  the MCP tool, and the GUI Memory Health card — three surfaces, one
+  source of truth.
+- **GUI Memory Health card.** Four KPI tiles below the existing Dashboard
+  metric row (embedding coverage, projects, contradictions outstanding,
+  last reflection). Hides itself silently if the DB is unreachable, so
+  intermittent-DB demo deploys keep working.
+- **Eval harness — `--offline-stub` and DB-free `--dry-run`.**
+  `--dry-run` no longer needs a DB or API key — it parses the questions
+  and exits 0. New `--offline-stub` runs the harness end-to-end with a
+  deterministic pretend-LLM (always 30/30 with-memory vs 0/30 cold), so
+  CI can prove the grader, retrieval glue, and report writer are intact
+  without spending tokens. Real eval runs use neither flag and call
+  Claude as before.
+- **CI `eval-smoke` job** (`.github/workflows/ci.yml`). Runs
+  `throughline status --json` against an unreachable Postgres and asserts
+  the payload still parses, then runs both eval modes and asserts the
+  Markdown report has the headline line. Catches the regression class
+  where the harness or status payload starts requiring a live DB or API
+  key — the failure mode that breaks fresh forks.
 - **Preload audit row.** `scripts/context_preload.py` now writes a
   `memory_reflections` row with `reflection_type='preload'` whenever the
   SessionStart hook fires. The row records the chunk IDs that were injected

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ See the full gallery below or browse [`docs/screenshots/`](docs/screenshots/).
 - **CSV / Excel / PDF export** *(v0.2.0)* — Three download buttons above every list view (Conversations, Memory, Memory Health, Skills, Knowledge Graph entities, Projects, Prompts, every Search and Semantic-Search scope). CSV is UTF-8 with BOM; Excel via `openpyxl`; PDF via `reportlab` (landscape A4, repeated headers, alternating row backgrounds, document title and timestamp). Missing optional deps degrade gracefully — buttons disappear and the page shows a `pip install` hint. CSV is always available.
 - **Calendar view** — Sessions plotted on a month grid, click a day to drill down.
 - **SQL console** — Free-form SQL for power users.
+- **Memory Health card** *(unreleased)* — Four KPI tiles on the Dashboard (embedding coverage %, projects, contradictions outstanding, last reflection). Sourced from `throughline.status.collect_status` so the card, the `throughline status` CLI, and the `memory.stats` MCP tool can never drift apart.
 
 ---
 
@@ -233,6 +234,7 @@ Run `throughline <cmd> --help` for the per-command options.
 | `throughline gui` | Start the Streamlit GUI |
 | `throughline install-hooks` | Install `SessionStart` hooks into `~/.claude/settings.json` |
 | `throughline backup` | One-shot `pg_dump` backup |
+| `throughline status` | DB health snapshot (table counts, embedding coverage, last extraction/reflection). Add `--json` for a machine-readable payload. |
 | `throughline version` | Print the installed version |
 
 The Makefile exposes common tasks (`install`, `test`, `gui`, `ingest`, `scan`,
@@ -249,7 +251,7 @@ Claude Code (and any other MCP client — Claude Desktop, Cursor, Zed,
 Continue) can read and write the memory database directly, across sessions,
 without going through a skill round-trip or a shell command.
 
-Eight tools are exposed:
+Nine tools are exposed:
 
 | Tool | What it does |
 |---|---|
@@ -261,6 +263,7 @@ Eight tools are exposed:
 | `memory.list_projects` | Distinct project names known to memory. |
 | `memory.recent_reflections` | Recent rows from the `memory_reflections` audit log — what the reflection engine and the preload hook have done. |
 | `memory.preload_summary` | The most recent SessionStart preload audit row: which chunks the hook injected for this project, and when. |
+| `memory.stats` | Aggregate health snapshot — same payload as `throughline status --json`: table counts, embedding coverage, contradictions outstanding, last extraction/reflection timestamps. Lets the agent decide whether to query or first run a reflection pass. |
 
 Every tool with a `project` parameter defaults to the basename of
 `$CLAUDE_PROJECT_DIR` so a session in one project cannot accidentally

--- a/evals/README.md
+++ b/evals/README.md
@@ -32,14 +32,40 @@ ground truth a human authored, not a second LLM's opinion.
 python evals/run_eval.py --questions evals/questions.jsonl --report evals/last_run.md
 ```
 
-Required:
+Required for a real run:
 - A populated `claude_memory` DB.
 - An OpenAI or Ollama embedding backend (for `memory.search`).
 - Either `ANTHROPIC_API_KEY` (uses the SDK) or the `claude` CLI on `$PATH`
   (used in headless `claude -p` mode). The runner auto-detects.
 
-`--dry-run` prints what would be asked without calling any LLM. Use it once
-to confirm your question set parses cleanly.
+### Smoke modes (no DB, no API key)
+
+Two flags let the harness be exercised on a fresh clone or a CI runner
+that has neither Postgres nor an API key. They are mutually exclusive.
+
+`--dry-run` parses the question file, skips retrieval entirely, and exits
+0. Use it to confirm your question set is syntactically valid before
+spending tokens.
+
+```bash
+python evals/run_eval.py --dry-run
+```
+
+`--offline-stub` runs the full pipeline (retrieval glue, grader, report
+writer) with a deterministic pretend-LLM that always emits the first
+expected substring in the with-memory condition and "I do not know" in
+the cold condition. By design it lands at **30/30 with-memory** vs
+**0/30 cold** — the goal is not to measure quality but to prove the
+plumbing is intact. The CI `eval-smoke` job runs this on every PR so the
+harness can't silently rot between releases.
+
+```bash
+python evals/run_eval.py --offline-stub --report /tmp/smoke.md
+```
+
+If the DB is unreachable, retrieval gracefully returns `[]` and the
+harness keeps going (it logs the backend error to stderr). That is by
+design: smoke tests should not fail on missing infrastructure.
 
 ## Question format
 


### PR DESCRIPTION
## Summary

Documentation follow-up for #16. Strictly additive — no behaviour change.

- README **Commands** table → adds `throughline status`.
- README **MCP Integration** table → "Eight tools" → "Nine tools", adds `memory.stats` row.
- README **Features → UI** → adds the Dashboard Memory Health card, calls out the shared `collect_status` helper that keeps CLI / MCP / GUI in lock-step.
- CHANGELOG **[Unreleased]** → five entries (status, memory.stats, GUI Memory Health, eval --offline-stub / DB-free --dry-run, CI eval-smoke).
- `evals/README.md` → new "Smoke modes (no DB, no API key)" subsection covering both flags, including the by-design 30/30 vs 0/30 result.

## Why a separate PR

The original feature PR was scoped tightly to "ship the features." Per the project's commit-scope-discipline rule, doc updates land separately so a future bisect or revert touches one concern at a time.

## Test plan

- [x] `pytest -q --ignore=tests/integration` — 112 passing (no test changes; sanity)
- [x] Markdown renders locally; tables aligned; cross-links resolve.
- [x] CHANGELOG.md is in `Keep a Changelog` format and the new entries sit under `[Unreleased]` so they ride the next version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)