### PR TITLE
feat: backfill-projects — populate projects table from observed project_names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`throughline backfill-projects` subcommand.** Populates the `projects`
+  table from distinct `project_name` values observed in `memory_chunks`
+  (and optionally `conversations`). Closes the gap where a fresh-ingested
+  DB referenced dozens of projects in chunks/conversations but the GUI
+  Projects page was empty because that table was only ever written by the
+  manual "New project" form. Idempotent (`ON CONFLICT (name) DO NOTHING`)
+  — re-running never clobbers manually-curated descriptions, contacts,
+  decisions or status. `--dry-run` previews; `--include-conversations`
+  widens the source net.
 - **`throughline status` subcommand.** Health snapshot of the memory DB:
   reachability, schema version (best-effort), table row counts,
   memory-chunk totals + by category, embedding coverage %, last-extraction

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Run `throughline <cmd> --help` for the per-command options.
 | `throughline install-hooks` | Install `SessionStart` hooks into `~/.claude/settings.json` |
 | `throughline backup` | One-shot `pg_dump` backup |
 | `throughline status` | DB health snapshot (table counts, embedding coverage, last extraction/reflection). Add `--json` for a machine-readable payload. |
+| `throughline backfill-projects` | Populate the `projects` table from observed `project_name` values in memory chunks. Idempotent. Add `--include-conversations` to widen, `--dry-run` to preview. |
 | `throughline version` | Print the installed version |
 
 The Makefile exposes common tasks (`install`, `test`, `gui`, `ingest`, `scan`,

--- a/scripts/backfill_projects.py
+++ b/scripts/backfill_projects.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Backfill the ``projects`` table from observed ``project_name`` values.
+
+The ``projects`` table is a manually-curated table (description, contacts,
+decisions, status). Nothing in the ingestion pipeline writes to it — only
+the GUI's "New project" form does. As a result, a freshly-ingested DB
+shows zero rows on the Projects page even though `memory_chunks` and
+`conversations` reference dozens of distinct project_names.
+
+This script closes that gap. For every distinct ``project_name`` observed
+in `memory_chunks` (and optionally `conversations`), insert a row into
+`projects` with the bare name and default status. Existing rows are left
+untouched (ON CONFLICT DO NOTHING) — manually-curated descriptions /
+contacts are never clobbered, so re-running is safe.
+
+Usage::
+
+    # Default: from memory_chunks only.
+    python scripts/backfill_projects.py
+
+    # Wider net: also consider conversations.
+    python scripts/backfill_projects.py --include-conversations
+
+    # Preview without writing.
+    python scripts/backfill_projects.py --dry-run
+
+    # Same options via the unified CLI:
+    throughline backfill-projects [--include-conversations] [--dry-run]
+
+Exit code: 0 on success (including dry-run), 2 on a usage error, 1 on
+DB failure.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import psycopg2
+
+
+def db_config() -> dict:
+    cfg = {
+        "host": os.environ.get("PGHOST", "localhost"),
+        "port": int(os.environ.get("PGPORT", "5432")),
+        "dbname": os.environ.get("PGDATABASE", "claude_memory"),
+        "user": os.environ.get("PGUSER", os.environ.get("USER") or "postgres"),
+        "connect_timeout": int(os.environ.get("PGCONNECT_TIMEOUT", "5")),
+    }
+    pw = os.environ.get("PGPASSWORD")
+    if pw:
+        cfg["password"] = pw
+    return cfg
+
+
+def collect_observed_names(conn, *, include_conversations: bool) -> list[str]:
+    """Return the sorted list of distinct project_name values worth backfilling.
+
+    Always considers `memory_chunks`. `conversations` is opt-in because
+    not every project that has a Claude session necessarily has memory
+    extracted from it yet — that's a noisier signal.
+    """
+    sources = ["memory_chunks"]
+    if include_conversations:
+        sources.append("conversations")
+
+    names: set[str] = set()
+    with conn.cursor() as cur:
+        for tbl in sources:
+            cur.execute(
+                f"SELECT DISTINCT project_name FROM public.{tbl} "
+                "WHERE project_name IS NOT NULL AND project_name <> ''"
+            )
+            for (n,) in cur.fetchall():
+                names.add(n)
+    return sorted(names)
+
+
+def existing_project_names(conn) -> set[str]:
+    with conn.cursor() as cur:
+        cur.execute("SELECT name FROM public.projects")
+        return {r[0] for r in cur.fetchall()}
+
+
+def insert_missing(conn, missing: list[str]) -> int:
+    """Insert rows for the given names. Idempotent via ON CONFLICT.
+
+    Returns the number of rows actually inserted (not counting conflicts).
+    """
+    if not missing:
+        return 0
+    with conn.cursor() as cur:
+        cur.executemany(
+            "INSERT INTO public.projects (name, status) VALUES (%s, 'active') "
+            "ON CONFLICT (name) DO NOTHING",
+            [(n,) for n in missing],
+        )
+        # cur.rowcount with executemany on psycopg2 is driver-dependent.
+        # Recount truthfully by querying the table afterwards in main().
+    conn.commit()
+    return len(missing)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="backfill_projects",
+        description=(
+            "Insert one row into the projects table for each distinct "
+            "project_name observed in memory_chunks (and optionally "
+            "conversations). Existing rows are never modified."
+        ),
+    )
+    ap.add_argument(
+        "--include-conversations",
+        action="store_true",
+        help=("Also pull project_names from the conversations table. Default "
+              "is memory_chunks only — the more signal-rich source."),
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be inserted; do not write to the DB.",
+    )
+    args = ap.parse_args(argv)
+
+    try:
+        conn = psycopg2.connect(**db_config())
+    except Exception as e:
+        print(f"[backfill] DB connect failed: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        observed = collect_observed_names(
+            conn, include_conversations=args.include_conversations,
+        )
+        existing = existing_project_names(conn)
+        to_insert = [n for n in observed if n not in existing]
+
+        sources = ["memory_chunks"]
+        if args.include_conversations:
+            sources.append("conversations")
+
+        print(f"[backfill] sources: {', '.join(sources)}")
+        print(f"[backfill] observed distinct project_names: {len(observed)}")
+        print(f"[backfill] already in projects table:        {len(existing)}")
+        print(f"[backfill] to insert:                        {len(to_insert)}")
+
+        if args.dry_run:
+            for n in to_insert[:20]:
+                print(f"  + {n}")
+            if len(to_insert) > 20:
+                print(f"  … (and {len(to_insert) - 20} more)")
+            print("[backfill] dry-run — no writes performed.")
+            return 0
+
+        if not to_insert:
+            print("[backfill] nothing to do.")
+            return 0
+
+        insert_missing(conn, to_insert)
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM public.projects")
+            total = int(cur.fetchone()[0])
+        print(f"[backfill] inserted {len(to_insert)} row(s); "
+              f"projects table now has {total}.")
+        return 0
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_backfill_projects.py
+++ b/tests/test_backfill_projects.py
@@ -1,0 +1,189 @@
+"""DB-free tests for ``scripts/backfill_projects.py``.
+
+The script's pure helpers (``collect_observed_names``,
+``existing_project_names``, ``insert_missing``) take a connection-like
+object, so we feed them an in-memory fake. The point is to verify the
+scoping rules (sources include/exclude conversations) and the
+idempotence semantics (existing names are skipped) without touching
+Postgres — the unit-tests CI job has no DB.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+
+# ── Fakes ────────────────────────────────────────────────────────────────────
+class _FakeCursor:
+    def __init__(self, *, mc_names: list[str], conv_names: list[str],
+                 existing: list[str]):
+        self.mc_names = mc_names
+        self.conv_names = conv_names
+        self.existing = existing
+        self.executemany_calls: list[tuple[str, list]] = []
+        self._buf: list[tuple] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, sql: str, params=None):
+        s = " ".join(sql.split())
+        if "DISTINCT project_name FROM public.memory_chunks" in s:
+            self._buf = [(n,) for n in self.mc_names]
+        elif "DISTINCT project_name FROM public.conversations" in s:
+            self._buf = [(n,) for n in self.conv_names]
+        elif "SELECT name FROM public.projects" in s:
+            self._buf = [(n,) for n in self.existing]
+        elif "SELECT count(*) FROM public.projects" in s:
+            self._buf = [(len(self.existing),)]
+        else:
+            self._buf = []
+
+    def executemany(self, sql: str, seq):
+        self.executemany_calls.append((sql, list(seq)))
+
+    def fetchall(self):
+        return list(self._buf)
+
+    def fetchone(self):
+        return self._buf[0] if self._buf else None
+
+
+class _FakeConn:
+    def __init__(self, cursor: _FakeCursor):
+        self._cursor = cursor
+        self.committed = 0
+
+    def cursor(self):
+        return self._cursor
+
+    def commit(self):
+        self.committed += 1
+
+    def close(self):
+        pass
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+def test_collect_observed_default_uses_memory_chunks_only():
+    import backfill_projects as bp
+
+    cur = _FakeCursor(
+        mc_names=["alpha", "beta", "gamma"],
+        conv_names=["delta", "epsilon"],
+        existing=[],
+    )
+    names = bp.collect_observed_names(_FakeConn(cur), include_conversations=False)
+    assert names == ["alpha", "beta", "gamma"]
+
+
+def test_collect_observed_with_conversations_unions_dedups_and_sorts():
+    import backfill_projects as bp
+
+    cur = _FakeCursor(
+        mc_names=["alpha", "beta", "gamma"],
+        conv_names=["beta", "delta"],   # overlap on "beta"
+        existing=[],
+    )
+    names = bp.collect_observed_names(_FakeConn(cur), include_conversations=True)
+    assert names == ["alpha", "beta", "delta", "gamma"]
+
+
+def test_existing_project_names_returns_a_set():
+    import backfill_projects as bp
+
+    cur = _FakeCursor(mc_names=[], conv_names=[], existing=["proj-x", "proj-y"])
+    out = bp.existing_project_names(_FakeConn(cur))
+    assert out == {"proj-x", "proj-y"}
+
+
+def test_insert_missing_executes_with_active_status_and_commits():
+    import backfill_projects as bp
+
+    cur = _FakeCursor(mc_names=[], conv_names=[], existing=[])
+    conn = _FakeConn(cur)
+    n = bp.insert_missing(conn, ["alpha", "beta"])
+
+    assert n == 2
+    assert conn.committed == 1
+    assert len(cur.executemany_calls) == 1
+    sql, rows = cur.executemany_calls[0]
+    assert "INSERT INTO public.projects" in sql
+    assert "ON CONFLICT (name) DO NOTHING" in sql
+    assert rows == [("alpha",), ("beta",)]
+
+
+def test_insert_missing_noop_on_empty_list():
+    import backfill_projects as bp
+
+    cur = _FakeCursor(mc_names=[], conv_names=[], existing=[])
+    conn = _FakeConn(cur)
+    assert bp.insert_missing(conn, []) == 0
+    assert conn.committed == 0
+    assert cur.executemany_calls == []
+
+
+def test_main_dry_run_does_not_write(monkeypatch, capsys):
+    import backfill_projects as bp
+
+    cur = _FakeCursor(
+        mc_names=["alpha", "beta"],
+        conv_names=[],
+        existing=["alpha"],
+    )
+    conn = _FakeConn(cur)
+    monkeypatch.setattr(bp, "psycopg2", type("P", (), {"connect": lambda **kw: conn}))
+
+    rc = bp.main(["--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "to insert: " in out
+    assert "+ beta" in out
+    assert "no writes" in out
+    # No INSERT, no commit.
+    assert cur.executemany_calls == []
+    assert conn.committed == 0
+
+
+def test_main_real_run_inserts_and_commits(monkeypatch, capsys):
+    import backfill_projects as bp
+
+    cur = _FakeCursor(
+        mc_names=["alpha", "beta"],
+        conv_names=[],
+        existing=["alpha"],
+    )
+    conn = _FakeConn(cur)
+    monkeypatch.setattr(bp, "psycopg2", type("P", (), {"connect": lambda **kw: conn}))
+
+    rc = bp.main([])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Only "beta" was missing.
+    assert "to insert:                        1" in out
+    assert "inserted 1 row" in out
+    sql, rows = cur.executemany_calls[0]
+    assert rows == [("beta",)]
+    assert conn.committed == 1
+
+
+def test_main_db_connect_failure_returns_1(monkeypatch, capsys):
+    import backfill_projects as bp
+
+    def _raise(**_kw):
+        raise RuntimeError("boom")
+    monkeypatch.setattr(bp, "psycopg2", type("P", (), {"connect": _raise}))
+
+    rc = bp.main([])
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "DB connect failed" in err

--- a/throughline/cli.py
+++ b/throughline/cli.py
@@ -199,6 +199,16 @@ def cmd_version(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_backfill_projects(args: argparse.Namespace) -> int:
+    """Insert one projects row for each project_name observed in memory."""
+    passthrough: list[str] = []
+    if args.include_conversations:
+        passthrough.append("--include-conversations")
+    if args.dry_run:
+        passthrough.append("--dry-run")
+    return _call_script_main("backfill_projects", passthrough)
+
+
 def cmd_status(args: argparse.Namespace) -> int:
     """Print a health snapshot of the memory DB.
 
@@ -370,6 +380,24 @@ def build_parser() -> argparse.ArgumentParser:
         help="Print the installed Throughline version and exit.",
     )
     p.set_defaults(func=cmd_version)
+
+    # backfill-projects
+    p = sub.add_parser(
+        "backfill-projects",
+        help="Populate the projects table from observed project_name values.",
+        description=(
+            "For each distinct project_name found in memory_chunks (and "
+            "optionally conversations), insert a row into the projects "
+            "table. Existing rows are never modified — manually-curated "
+            "descriptions, contacts, decisions are safe. Idempotent: "
+            "re-running adds only the genuinely new names."
+        ),
+    )
+    p.add_argument("--include-conversations", action="store_true",
+                   help="Also pull project_names from the conversations table.")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Preview what would be inserted; do not write.")
+    p.set_defaults(func=cmd_backfill_projects)
 
     # status
     p = sub.add_parser(


### PR DESCRIPTION
## Summary

Closes the GUI Projects page's "no projects" surprise: `memory_chunks` (and `conversations`) reference dozens of distinct `project_name` values, but the `projects` **table** was only ever written by the GUI's manual "New project" form, so the page was empty by design until you typed something. After this PR, `throughline backfill-projects` populates it from observed names.

- New script `scripts/backfill_projects.py` with `--dry-run` and `--include-conversations`.
- New CLI subcommand `throughline backfill-projects` (wraps the script the standard way).
- `INSERT ... ON CONFLICT (name) DO NOTHING` — manually-curated descriptions/contacts/decisions/status on existing rows are never modified. Idempotent; re-running adds only genuinely new names.
- 8 new DB-free unit tests covering source selection, idempotence semantics, the dry-run no-write contract, the real-run executemany+commit contract, and the connect-failure exit code.
- README Commands table + CHANGELOG `[Unreleased]` updated alongside the feature so the "what changed" answer lives in three places that don't drift.

## Why this scope

Same operational story as `throughline status` and `memory.stats`: the new `Projects` KPI on the Memory Health card counts DISTINCT `project_name` from chunks (52+ on a real install), while the Projects page reads the curated table (0 by default). Same label, different sources, confusing UX. After backfill the two numbers agree, which is the user-facing behaviour you'd expect.

Did **not** add a launchd / systemd job to auto-run this on a schedule — that's a deliberate follow-up choice. Backfill is cheap and idempotent, but adding a third schedule-managed pipeline step is opinionated and worth a separate decision.

## Test plan

- [x] `pytest -q --ignore=tests/integration` — 120 passing (112 baseline + 8 new)
- [x] `python3 -m throughline backfill-projects --dry-run` — lists 53 candidates, no writes
- [x] `python3 -m throughline backfill-projects` — inserted 53 rows on a real install
- [x] Re-running is a no-op: `[backfill] nothing to do.`
- [x] After backfill, GUI Projects page renders all 53 rows.
- [x] Memory Health card "Projects" KPI now matches the Projects-page count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)