### PR TITLE
feat(gui): Projects page — sort, list view, synthesised descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **GUI Projects page — sort, list view, synthesised descriptions.** The
+  page now has a Sort selector (Recent activity / Created / Name /
+  Memory volume / Status) and a Cards|List view toggle. Each row joins
+  live activity stats from `memory_chunks` + `conversations` so projects
+  with empty `description` fields render a synthesised blurb (e.g.
+  *"42 chunks · 6 conversations · last active 2 weeks ago"*) instead of
+  a static "No description". Sorting by Recent activity makes the page
+  useful immediately after `throughline backfill-projects`, when every
+  curated row has the same `created_at`.
 - **`throughline backfill-projects` subcommand.** Populates the `projects`
   table from distinct `project_name` values observed in `memory_chunks`
   (and optionally `conversations`). Closes the gap where a fresh-ingested

--- a/gui/app.py
+++ b/gui/app.py
@@ -3210,15 +3210,75 @@ elif page == "Projects":
                 except json.JSONDecodeError:
                     st.error("Contacts must be valid JSON.")
 
+    # ── Sort + view controls ─────────────────────────────────────────────
+    sort_col, view_col = st.columns([3, 2])
+    with sort_col:
+        sort_by = st.selectbox(
+            "Sort by",
+            options=[
+                ("last_activity", "Recent activity"),
+                ("created_at",    "Created"),
+                ("name",          "Name (A→Z)"),
+                ("chunks_count",  "Memory volume"),
+                ("status",        "Status"),
+            ],
+            format_func=lambda x: x[1],
+            key="proj_sort",
+        )
+    with view_col:
+        view_mode = st.radio(
+            "View",
+            options=["Cards", "List"],
+            horizontal=True,
+            key="proj_view",
+        )
+
+    sort_key = sort_by[0]
+    # Most-useful sort direction per column.
+    sort_dir = "ASC" if sort_key == "name" else "DESC"
+
+    # Pull the curated rows + activity stats observed in chunks/conversations.
+    # LEFT JOIN so projects with no matching chunks (e.g. just-created via the
+    # form) still render — they just show 0 chunks and a NULL last_activity.
+    sql = f"""
+        SELECT
+            p.id,
+            p.name,
+            p.description,
+            p.status::text                                       AS status,
+            p.created_at,
+            COALESCE(mc.chunks_count, 0)                         AS chunks_count,
+            COALESCE(cv.conversations_count, 0)                  AS conversations_count,
+            GREATEST(mc.last_activity, cv.last_activity)         AS last_activity,
+            LEAST(mc.first_activity, cv.first_activity)          AS first_activity
+        FROM projects p
+        LEFT JOIN (
+            SELECT project_name,
+                   count(*)        AS chunks_count,
+                   max(created_at) AS last_activity,
+                   min(created_at) AS first_activity
+            FROM memory_chunks
+            WHERE project_name IS NOT NULL
+            GROUP BY project_name
+        ) mc ON mc.project_name = p.name
+        LEFT JOIN (
+            SELECT project_name,
+                   count(*)        AS conversations_count,
+                   max(started_at) AS last_activity,
+                   min(started_at) AS first_activity
+            FROM conversations
+            WHERE project_name IS NOT NULL
+            GROUP BY project_name
+        ) cv ON cv.project_name = p.name
+        ORDER BY {sort_key} {sort_dir} NULLS LAST, p.name ASC
+    """
     with st.spinner("Loading projects..."):
-        df = q("""SELECT id, name, description, status::text AS status, created_at
-                  FROM projects
-                  ORDER BY created_at DESC NULLS LAST, name""")
+        df = q(sql)
     if df.empty:
         st.info("No projects.")
     else:
         st.markdown(
-            f'<div class="kai-section-label">{len(df)} projects</div>',
+            f'<div class="kai-section-label">{len(df)} projects · sorted by {sort_by[1].lower()}</div>',
             unsafe_allow_html=True,
         )
         render_export_buttons(
@@ -3226,25 +3286,67 @@ elif page == "Projects":
             filename_base="projects",
             title="Projects",
         )
-        cols = st.columns(2)
-        for i, (_, row) in enumerate(df.iterrows()):
-            col = cols[i % 2]
-            with col:
+
+        def _activity_blurb(row) -> str:
+            """Synthesised description when the curated one is empty.
+            Reads as: '42 chunks · 6 conversations · last active 2 weeks ago'."""
+            chunks = int(row.get("chunks_count") or 0)
+            convs = int(row.get("conversations_count") or 0)
+            parts: list[str] = []
+            if chunks:
+                parts.append(f"{chunks:,} chunk{'s' if chunks != 1 else ''}")
+            if convs:
+                parts.append(f"{convs:,} conversation{'s' if convs != 1 else ''}")
+            la = row.get("last_activity")
+            if la is not None and not pd.isna(la):
+                parts.append(f"last active {fmt_dt(la, compact=True)}")
+            if not parts:
+                return "No description · no activity recorded yet"
+            return " · ".join(parts)
+
+        if view_mode == "Cards":
+            cols = st.columns(2)
+            for i, (_, row) in enumerate(df.iterrows()):
+                col = cols[i % 2]
+                with col:
+                    sc = STATUS_COLORS.get(row["status"], ACCENT)
+                    desc = row["description"] or _activity_blurb(row)
+                    desc_short = desc[:220] + ("…" if len(desc) > 220 else "")
+                    st.markdown(
+                        f"""<div class="kai-list-card" style="min-height:150px;display:flex;flex-direction:column;">
+                            <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;">
+                                <div style="font-size:15px;font-weight:600;color:{TEXT};letter-spacing:-0.01em;">{row['name']}</div>
+                                <div>{badge(row["status"], sc)}</div>
+                            </div>
+                            <div style="font-size:12.5px;color:{TEXT_MUTED};line-height:1.55;flex:1;">{desc_short}</div>
+                        </div>""",
+                        unsafe_allow_html=True,
+                    )
+                    if st.button("Open", key=f"pr_open_{row['id']}"):
+                        go_to_detail("project", int(row["id"]))
+        else:
+            # ── List view: compact one-line-per-project rendering ────────
+            for _, row in df.iterrows():
                 sc = STATUS_COLORS.get(row["status"], ACCENT)
-                desc = row["description"] or "No description"
-                desc_short = desc[:220] + ("..." if len(desc) > 220 else "")
-                st.markdown(
-                    f"""<div class="kai-list-card" style="min-height:150px;display:flex;flex-direction:column;">
-                        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;">
-                            <div style="font-size:15px;font-weight:600;color:{TEXT};letter-spacing:-0.01em;">{row['name']}</div>
-                            <div>{badge(row["status"], sc)}</div>
-                        </div>
-                        <div style="font-size:12.5px;color:{TEXT_MUTED};line-height:1.55;flex:1;">{desc_short}</div>
-                    </div>""",
-                    unsafe_allow_html=True,
-                )
-                if st.button("Open", key=f"pr_open_{row['id']}"):
-                    go_to_detail("project", int(row["id"]))
+                desc = row["description"] or _activity_blurb(row)
+                desc_short = desc[:140] + ("…" if len(desc) > 140 else "")
+                col_card, col_btn = st.columns([10, 1])
+                with col_card:
+                    st.markdown(
+                        f"""<div class="kai-list-card" style="padding:12px 16px;">
+                            <div style="display:flex;justify-content:space-between;align-items:center;gap:12px;">
+                                <div style="display:flex;flex-direction:column;min-width:0;flex:1;">
+                                    <div style="font-size:14px;font-weight:600;color:{TEXT};letter-spacing:-0.01em;">{row['name']}</div>
+                                    <div style="font-size:12px;color:{TEXT_MUTED};line-height:1.4;margin-top:3px;">{desc_short}</div>
+                                </div>
+                                <div style="flex-shrink:0;">{badge(row["status"], sc)}</div>
+                            </div>
+                        </div>""",
+                        unsafe_allow_html=True,
+                    )
+                with col_btn:
+                    if st.button("Open", key=f"pr_open_{row['id']}", use_container_width=True):
+                        go_to_detail("project", int(row["id"]))
 
 elif page == "Prompts":
     page_header("Prompts", "Reusable prompt library")


### PR DESCRIPTION
## Summary

Three improvements to the Projects page, addressing the three things you noticed after running `throughline backfill-projects` against your live DB:

- **Sort selector** above the grid: Recent activity / Created / Name / Memory volume / Status. The default is **Recent activity** — sorting by the actual `max(created_at)` across `memory_chunks` + `conversations` per `project_name`. Fixes the "everything looks alphabetical" problem when every backfilled row has the same `created_at`.
- **Cards | List view toggle** next to it. Cards is the existing 2-column layout. List is a compact one-row-per-project rendering for scanning 50+ projects without scrolling.
- **Synthesised description fallback.** When `projects.description` is NULL (the default after backfill) the card / row now shows live activity stats — *"42 chunks · 6 conversations · last active 2 weeks ago"* — instead of a static "No description". Manually-edited descriptions still take priority.

## Implementation note

The page query LEFT-JOINs aggregated stats from `memory_chunks` and `conversations`. LEFT JOIN means projects with no observed activity (e.g. someone added them through the "New project" form before any chunks landed) still render — they show 0/0 and "no activity recorded yet" rather than vanishing.

No schema change. No new dependencies. Single file diff (`gui/app.py`) plus a CHANGELOG entry.

## Test plan

- [x] `pytest -q --ignore=tests/integration` — 120 passing (no test changes; behavioural sanity)
- [x] `python3 -c "import gui.app"` — imports clean
- [x] Streamlit hot-reload picks up the new code on the running instance
- [x] Manual: with 53 backfilled projects, switching Sort and View options re-renders correctly; descriptions show synthesised blurbs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)