### PR TITLE
fix(ingest): cwd-based project_path; token totals from usage; repair script for existing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`scripts/ingest_sessions.py` no longer mangles project paths.** It
+  now reads the JSONL `cwd` field (recorded by Claude Code on every
+  message) instead of reconstructing a path by replacing every `-` in
+  the session-hash directory name with `/`. The hash-replace approach
+  silently destroyed project names that contained a hyphen
+  (`claude-memory-db` → `claude/memory/db`). The hash-derived path is
+  retained as a fallback for older JSONL files that pre-date the
+  `cwd` field.
+- **`conversations.token_count_in` / `token_count_out` are now
+  populated by ingest.** The original ingest never set these columns;
+  every conversation showed 0 / 0 even on long-lived sessions that had
+  burned millions of tokens. The new ingest reads each assistant
+  message's `usage` block (`input_tokens` + `cache_creation_input_tokens`
+  + `cache_read_input_tokens` for input total, `output_tokens` for
+  output total) and aggregates per session.
+- **Per-message `messages.token_count` is now populated** with the same
+  per-turn total, so message-level filtering and GUI tooltips can use
+  it.
+- **GUI: token counts ≥ 10,000 render compactly.** New `fmt_count`
+  helper turns 1,200,000 into `1.2 M` and 5,700,000,000 into `5.70 B`.
+  Below 10,000 the comma-grouped integer remains for readability.
+  Applied to the Conversation detail Tokens-in / Tokens-out tiles.
+- **`scripts/repair_conversations.py` (and `throughline
+  repair-conversations`)** — one-shot repair for already-ingested rows.
+  Reads each JSONL file referenced via `ingestion_log`, groups by
+  `sessionId` (so subagent JSONLs aggregate into the parent
+  conversation rather than overwriting it), re-derives `project_path`
+  from `cwd`, and recomputes token totals. Idempotent (no-op on the
+  second run); `--dry-run` previews; `--limit N` caps for smoke runs.
+  On a real install: 3,146 conversations repaired in 6 seconds; the
+  `claude-memory-db` Conversations tab went from 0 to 2,287 rows; 4.8 B
+  input tokens / 20.9 M output tokens recovered across 2,844 conversations.
+- **Schema migration `001_widen_conversation_token_counts.sql`.**
+  `conversations.token_count_in` / `token_count_out` are now `bigint`
+  (were `integer`); long-lived sessions easily exceed 2 billion when
+  cache-creation and cache-read tokens are summed in.
 - **Project detail tabs now find conversations / skills / prompts whose
   paths contain a hyphenated repo name.** Root cause:
   `scripts/ingest_sessions.py` derives `conversations.project_path` from

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Run `throughline <cmd> --help` for the per-command options.
 | `throughline backup` | One-shot `pg_dump` backup |
 | `throughline status` | DB health snapshot (table counts, embedding coverage, last extraction/reflection). Add `--json` for a machine-readable payload. |
 | `throughline backfill-projects` | Populate the `projects` table from observed `project_name` values in memory chunks. Idempotent. Add `--include-conversations` to widen, `--dry-run` to preview. |
+| `throughline repair-conversations` | Re-read JSONL files and repair existing `conversations` rows: `project_path` (was hyphen-mangled by older ingest) and `token_count_in` / `token_count_out` (were never populated). Idempotent. |
 | `throughline version` | Print the installed version |
 
 The Makefile exposes common tasks (`install`, `test`, `gui`, `ingest`, `scan`,

--- a/gui/app.py
+++ b/gui/app.py
@@ -660,6 +660,32 @@ def fmt_dt(x, compact: bool = False) -> str:
         return "—"
 
 
+def fmt_count(x) -> str:
+    """Humanise a count: 0 → '0', 1234 → '1,234', 1.3M / 4.2K / 5.7B.
+
+    Used wherever the raw integer is too noisy (token totals on the
+    Conversation detail page hit the billions on long-lived sessions).
+    Threshold for compaction is 10,000 — below that the comma-grouped
+    integer is still readable.
+    """
+    if x is None:
+        return "—"
+    try:
+        if isinstance(x, float) and pd.isna(x):
+            return "—"
+        n = int(x)
+    except Exception:
+        return "—"
+    abs_n = abs(n)
+    if abs_n < 10_000:
+        return f"{n:,}"
+    if abs_n < 1_000_000:
+        return f"{n/1_000:.1f} K"
+    if abs_n < 1_000_000_000:
+        return f"{n/1_000_000:.1f} M"
+    return f"{n/1_000_000_000:.2f} B"
+
+
 def badge(text: str, color: str = ACCENT) -> str:
     return (f'<span style="display:inline-block;padding:2px 8px;border-radius:99px;'
             f'font-size:10.5px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;'
@@ -1018,9 +1044,9 @@ if detail_type == "conversation":
         st.markdown('<hr/>', unsafe_allow_html=True)
 
         m1, m2, m3, m4 = st.columns(4)
-        m1.metric("Messages", int(c["message_count"] or 0))
-        m2.metric("Tokens in", int(c["token_count_in"] or 0))
-        m3.metric("Tokens out", int(c["token_count_out"] or 0))
+        m1.metric("Messages", fmt_count(c["message_count"]))
+        m2.metric("Tokens in", fmt_count(c["token_count_in"]))
+        m3.metric("Tokens out", fmt_count(c["token_count_out"]))
         m4.metric("Started", fmt_dt(c["started_at"]))
 
         with st.expander("Edit title"):

--- a/scripts/ingest_sessions.py
+++ b/scripts/ingest_sessions.py
@@ -118,8 +118,29 @@ def parse_timestamp(ts_str: str) -> datetime:
         return datetime.now(timezone.utc)
 
 
+def _first_cwd(entries: list[dict[str, Any]]) -> str | None:
+    """Return the first non-empty ``cwd`` field across all entries.
+
+    Claude Code records the user's working directory on most entries.
+    Reading it directly is correct; the historical alternative —
+    reconstructing a path from the on-disk session-hash directory name
+    by replacing every ``-`` with ``/`` — silently mangles any project
+    whose name contains a hyphen (``claude-memory-db`` → ``claude/memory/db``).
+    """
+    for e in entries:
+        cwd = e.get("cwd")
+        if isinstance(cwd, str) and cwd.strip():
+            return cwd
+    return None
+
+
 def ingest_file(cursor: Any, filepath: Path, project_path: str | None) -> int:
-    """Ingestiert eine einzelne JSONL-Datei. Gibt die Anzahl eingefügter Messages zurück."""
+    """Ingestiert eine einzelne JSONL-Datei. Gibt die Anzahl eingefügter Messages zurück.
+
+    The ``project_path`` arg is now a *fallback*: if any JSONL entry
+    carries a real ``cwd`` we prefer that. The fallback is still useful
+    for older JSONL files that pre-date the cwd field.
+    """
     entries: list[dict[str, Any]] = []
     with open(filepath, "r", encoding="utf-8") as f:
         for line_num, line in enumerate(f, 1):
@@ -140,6 +161,11 @@ def ingest_file(cursor: Any, filepath: Path, project_path: str | None) -> int:
     if not msg_entries:
         return 0
 
+    # Prefer the JSONL-recorded cwd over the hash-derived fallback.
+    real_cwd = _first_cwd(entries)
+    if real_cwd:
+        project_path = real_cwd
+
     # Session-Metadaten aus erstem Eintrag
     first = msg_entries[0]
     session_id = first.get("sessionId")
@@ -159,17 +185,28 @@ def ingest_file(cursor: Any, filepath: Path, project_path: str | None) -> int:
             model = m["model"]
             break
 
+    # Pre-aggregate token usage so the conversations row carries totals on
+    # the way in. The Anthropic usage shape on assistant messages is
+    #   {input_tokens, output_tokens, cache_creation_input_tokens,
+    #    cache_read_input_tokens, …}
+    # The historically stored "token_count_in" maps to the sum of all input
+    # categories (raw + cache-creation + cache-read), since each is a real
+    # cost-incurring input read; "token_count_out" is just output_tokens.
+    conv_tokens_in, conv_tokens_out = _sum_usage(msg_entries)
+
     # Conversation einfügen
     try:
         cursor.execute("""
             INSERT INTO conversations (session_id, project_path, model, entrypoint, git_branch,
-                                       started_at, ended_at, message_count, metadata)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                                       started_at, ended_at, message_count,
+                                       token_count_in, token_count_out, metadata)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (session_id) DO NOTHING
             RETURNING id
         """, (
             session_id, project_path, model, entrypoint, git_branch,
-            started_at, ended_at, len(msg_entries), Json({})
+            started_at, ended_at, len(msg_entries),
+            conv_tokens_in, conv_tokens_out, Json({})
         ))
         result = cursor.fetchone()
         if result is None:
@@ -195,18 +232,22 @@ def ingest_file(cursor: Any, filepath: Path, project_path: str | None) -> int:
         parent_uuid = entry.get("parentUuid")
         is_sidechain = entry.get("isSidechain", False)
         msg_model = msg.get("model")
+        # Per-message token total: assistant messages carry usage; user
+        # messages don't. Storing total (in+out) so a single column reads
+        # as "tokens this turn cost".
+        msg_token_count = _per_message_total(msg)
 
         try:
             cursor.execute("""
                 INSERT INTO messages (conversation_id, uuid, parent_uuid, role, content,
                                      content_blocks, tool_calls, tool_name, is_sidechain,
-                                     model, created_at, metadata)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                                     model, token_count, created_at, metadata)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """, (
                 conv_id, uuid_val, parent_uuid, role, content,
                 Json(msg.get("content")) if isinstance(msg.get("content"), list) else None,
                 Json(tool_calls) if tool_calls else None,
-                tool_name, is_sidechain, msg_model, ts, Json({})
+                tool_name, is_sidechain, msg_model, msg_token_count, ts, Json({})
             ))
             msg_count += 1
         except Exception as e:
@@ -214,6 +255,39 @@ def ingest_file(cursor: Any, filepath: Path, project_path: str | None) -> int:
             continue
 
     return msg_count
+
+
+def _per_message_total(message: dict[str, Any]) -> int | None:
+    """Per-message tokens total. None when no usage is present."""
+    u = message.get("usage")
+    if not isinstance(u, dict):
+        return None
+    return (
+        int(u.get("input_tokens") or 0)
+        + int(u.get("cache_creation_input_tokens") or 0)
+        + int(u.get("cache_read_input_tokens") or 0)
+        + int(u.get("output_tokens") or 0)
+    ) or None
+
+
+def _sum_usage(entries: list[dict[str, Any]]) -> tuple[int, int]:
+    """Sum input vs output tokens across all assistant messages in entries."""
+    in_total = 0
+    out_total = 0
+    for e in entries:
+        m = e.get("message")
+        if not isinstance(m, dict):
+            continue
+        u = m.get("usage")
+        if not isinstance(u, dict):
+            continue
+        in_total += (
+            int(u.get("input_tokens") or 0)
+            + int(u.get("cache_creation_input_tokens") or 0)
+            + int(u.get("cache_read_input_tokens") or 0)
+        )
+        out_total += int(u.get("output_tokens") or 0)
+    return in_total, out_total
 
 
 def main() -> None:

--- a/scripts/repair_conversations.py
+++ b/scripts/repair_conversations.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Repair existing ``conversations`` rows from the original JSONL files.
+
+Two ingest bugs left bad data on disk:
+
+1. ``project_path`` was reconstructed from Claude Code's session-hash
+   directory name by replacing every ``-`` with ``/``. Any project
+   whose name contains a hyphen (``claude-memory-db``,
+   ``daily-mail-drafter``, …) ends up stored as a corrupted path with
+   the hyphenated component split into directory levels.
+
+2. ``token_count_in`` / ``token_count_out`` were never populated; the
+   columns sat at NULL/0 even though the JSONL ``usage`` blocks carried
+   the real numbers all along.
+
+This script fixes both, in place, by re-reading the original JSONL files
+referenced via ``ingestion_log``. Idempotent (an ``UPDATE`` is only
+issued when at least one column would change), safe to re-run, and
+``--dry-run`` previews the diff without writing.
+
+Usage::
+
+    python scripts/repair_conversations.py             # full repair
+    python scripts/repair_conversations.py --dry-run   # preview only
+    python scripts/repair_conversations.py --limit 50  # cap rows touched
+
+    # Same options via the unified CLI:
+    throughline repair-conversations [--dry-run] [--limit N]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import psycopg2
+
+
+def db_config() -> dict:
+    cfg = {
+        "host": os.environ.get("PGHOST", "localhost"),
+        "port": int(os.environ.get("PGPORT", "5432")),
+        "dbname": os.environ.get("PGDATABASE", "claude_memory"),
+        "user": os.environ.get("PGUSER", os.environ.get("USER") or "postgres"),
+        "connect_timeout": int(os.environ.get("PGCONNECT_TIMEOUT", "5")),
+    }
+    pw = os.environ.get("PGPASSWORD")
+    if pw:
+        cfg["password"] = pw
+    return cfg
+
+
+def parse_jsonl(path: Path) -> tuple[str | None, int, int, str | None]:
+    """Return (cwd, tokens_in, tokens_out, session_id) for a JSONL file.
+
+    cwd / session_id are None if the file is empty / unreadable. tokens_*
+    are zero in the same case. Skips malformed lines silently — the
+    ingest pipeline already prints a per-line error during the original
+    ingest, so doing it twice would be noisy.
+    """
+    cwd: str | None = None
+    in_total = 0
+    out_total = 0
+    session_id: str | None = None
+    if not path.exists():
+        return None, 0, 0, None
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                d = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if cwd is None:
+                c = d.get("cwd")
+                if isinstance(c, str) and c.strip():
+                    cwd = c
+            if session_id is None:
+                s = d.get("sessionId")
+                if isinstance(s, str) and s:
+                    session_id = s
+            m = d.get("message")
+            if isinstance(m, dict):
+                u = m.get("usage")
+                if isinstance(u, dict):
+                    in_total += (
+                        int(u.get("input_tokens") or 0)
+                        + int(u.get("cache_creation_input_tokens") or 0)
+                        + int(u.get("cache_read_input_tokens") or 0)
+                    )
+                    out_total += int(u.get("output_tokens") or 0)
+    return cwd, in_total, out_total, session_id
+
+
+def repair_session(conn, *, session_id: str, file_paths: list[str], dry_run: bool) -> dict:
+    """Repair a single session by aggregating across ALL its JSONL files.
+
+    Subagent JSONLs share their parent's ``sessionId``; processing each
+    file independently and overwriting the conversations row meant
+    last-file-wins, which was both wrong (subagent tokens dropped) and
+    non-idempotent (file iteration order depended on ``ingested_at``).
+    Aggregating across the full set of files for one session_id gives
+    the correct total and lands the same number on every re-run.
+
+    Returns one of: skipped / no-change / updated / would-update.
+    """
+    cwd: str | None = None
+    in_total = 0
+    out_total = 0
+    seen_any = False
+    for fp in file_paths:
+        c, ti, to, _ = parse_jsonl(Path(fp))
+        if c is None and ti == 0 and to == 0:
+            continue
+        seen_any = True
+        if cwd is None and c is not None:
+            cwd = c
+        in_total += ti
+        out_total += to
+    if not seen_any:
+        return {"status": "skipped", "reason": "no-readable-jsonl"}
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, project_path, token_count_in, token_count_out "
+            "FROM public.conversations WHERE session_id = %s",
+            (session_id,),
+        )
+        row = cur.fetchone()
+    if not row:
+        return {"status": "skipped", "reason": "row-not-found"}
+    conv_id, old_path, old_in, old_out = row
+    old_in = int(old_in or 0)
+    old_out = int(old_out or 0)
+
+    new_path = cwd if cwd else old_path
+    new_in = in_total or old_in
+    new_out = out_total or old_out
+
+    changes: dict[str, tuple] = {}
+    if new_path != old_path and new_path is not None:
+        changes["project_path"] = (old_path, new_path)
+    if new_in != old_in:
+        changes["token_count_in"] = (old_in, new_in)
+    if new_out != old_out:
+        changes["token_count_out"] = (old_out, new_out)
+    if not changes:
+        return {"status": "no-change"}
+
+    if dry_run:
+        return {"status": "would-update", "id": conv_id, "changes": changes}
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE public.conversations "
+            "SET project_path = %s, token_count_in = %s, token_count_out = %s "
+            "WHERE id = %s",
+            (new_path, new_in, new_out, conv_id),
+        )
+    conn.commit()
+    return {"status": "updated", "id": conv_id, "changes": changes}
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="repair_conversations",
+        description=(
+            "Re-read Claude Code JSONL files referenced via ingestion_log "
+            "and repair conversations.project_path (cwd-based, not "
+            "hash-mangled) and token_count_in / token_count_out (which "
+            "were never populated by the original ingest)."
+        ),
+    )
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Preview changes; do not write to the DB.")
+    ap.add_argument("--limit", type=int, default=None,
+                    help="Cap on number of files processed (smoke testing).")
+    args = ap.parse_args(argv)
+
+    try:
+        conn = psycopg2.connect(**db_config())
+    except Exception as e:
+        print(f"[repair] DB connect failed: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        # Group ingestion_log files by session_id (extracted from JSONL).
+        # The same session_id can span many files: the parent transcript
+        # plus one subagent file per dispatched subagent. Aggregating
+        # across the whole group is the only way to land the correct
+        # token totals.
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT file_path FROM public.ingestion_log "
+                "WHERE file_path LIKE %s ORDER BY ingested_at",
+                ("%.jsonl",),
+            )
+            paths = [r[0] for r in cur.fetchall()]
+
+        if args.limit:
+            paths = paths[: args.limit]
+
+        print(f"[repair] {len(paths)} JSONL file(s) to inspect")
+
+        # Build session_id → [paths] map.
+        by_session: dict[str, list[str]] = {}
+        unreadable = 0
+        for fp in paths:
+            _c, _i, _o, sid = parse_jsonl(Path(fp))
+            if not sid:
+                unreadable += 1
+                continue
+            by_session.setdefault(sid, []).append(fp)
+
+        print(f"[repair] grouped into {len(by_session)} session(s); "
+              f"{unreadable} file(s) unreadable / no session id")
+
+        n_updated = 0
+        n_would = 0
+        n_nochange = 0
+        n_skipped = 0
+        sample: list[dict] = []
+        for sid, files in by_session.items():
+            res = repair_session(conn, session_id=sid, file_paths=files, dry_run=args.dry_run)
+            s = res["status"]
+            if s == "updated":
+                n_updated += 1
+            elif s == "would-update":
+                n_would += 1
+                if len(sample) < 5:
+                    sample.append(res)
+            elif s == "no-change":
+                n_nochange += 1
+            else:
+                n_skipped += 1
+
+        print(f"[repair] no-change:    {n_nochange}")
+        print(f"[repair] skipped:      {n_skipped}")
+        if args.dry_run:
+            print(f"[repair] would update: {n_would}")
+            for s in sample:
+                print(f"  conv #{s['id']}:")
+                for col, (old, new) in s["changes"].items():
+                    print(f"    {col}: {old!r} → {new!r}")
+            if n_would > len(sample):
+                print(f"  … (and {n_would - len(sample)} more)")
+        else:
+            print(f"[repair] updated:      {n_updated}")
+        return 0
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sql/migrations/001_widen_conversation_token_counts.sql
+++ b/sql/migrations/001_widen_conversation_token_counts.sql
@@ -1,0 +1,35 @@
+-- Widen conversations.token_count_in and conversations.token_count_out
+-- from integer to bigint so the per-session token totals (which include
+-- cache-creation and cache-read tokens, easily into the billions on a
+-- long-lived session) fit without an out-of-range exception.
+--
+-- The original ingest never populated these columns, so the only
+-- existing values are zeros — a widening cast is therefore lossless.
+-- The repair script `scripts/repair_conversations.py` then back-fills
+-- correct totals from the JSONL `usage` blocks.
+--
+-- ALTER COLUMN ... TYPE refuses to run while a view depends on the
+-- column, so v_conversation_stats is dropped and re-created in the
+-- same transaction. The view definition is unchanged.
+
+BEGIN;
+
+DROP VIEW IF EXISTS public.v_conversation_stats;
+
+ALTER TABLE public.conversations
+    ALTER COLUMN token_count_in  TYPE bigint USING token_count_in::bigint;
+
+ALTER TABLE public.conversations
+    ALTER COLUMN token_count_out TYPE bigint USING token_count_out::bigint;
+
+CREATE OR REPLACE VIEW public.v_conversation_stats AS
+ SELECT project_name,
+        count(*)                                       AS sessions,
+        sum(message_count)                             AS total_messages,
+        round(avg(token_count_in + token_count_out))   AS avg_tokens,
+        sum(cost_usd)                                  AS total_cost
+ FROM   conversations
+ GROUP  BY project_name
+ ORDER  BY count(*) DESC;
+
+COMMIT;

--- a/tests/test_repair_conversations.py
+++ b/tests/test_repair_conversations.py
@@ -1,0 +1,259 @@
+"""DB-free tests for ``scripts/repair_conversations.py`` and the token
+helpers in ``scripts/ingest_sessions.py``.
+
+We never connect to Postgres here. The repair logic operates on a fake
+connection / cursor, and the ingest helpers (``_first_cwd``,
+``_per_message_total``, ``_sum_usage``) are pure functions over Python
+dicts.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+
+# ── Fakes ────────────────────────────────────────────────────────────────────
+class _FakeCursor:
+    def __init__(self, *, row=None, rows=None):
+        self._row = row
+        self._rows = rows or []
+        self.executed: list[tuple[str, tuple | None]] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+
+    def fetchone(self):
+        return self._row
+
+    def fetchall(self):
+        return list(self._rows)
+
+
+class _FakeConn:
+    def __init__(self):
+        self.cursors: list[_FakeCursor] = []
+        self.committed = 0
+
+    def push(self, cur: _FakeCursor):
+        self.cursors.append(cur)
+
+    def cursor(self):
+        return self.cursors.pop(0)
+
+    def commit(self):
+        self.committed += 1
+
+    def close(self):
+        pass
+
+
+# ── Ingest token helpers ─────────────────────────────────────────────────────
+def test_first_cwd_returns_first_non_empty():
+    import ingest_sessions as ing
+    entries = [
+        {"type": "user", "cwd": ""},
+        {"type": "user", "cwd": None},
+        {"type": "user"},
+        {"type": "user", "cwd": "/Users/me/repo"},
+        {"type": "user", "cwd": "/Users/me/other"},
+    ]
+    assert ing._first_cwd(entries) == "/Users/me/repo"
+
+
+def test_first_cwd_returns_none_when_absent():
+    import ingest_sessions as ing
+    entries = [{"type": "user"}, {"type": "user", "cwd": ""}]
+    assert ing._first_cwd(entries) is None
+
+
+def test_per_message_total_sums_all_usage_categories():
+    import ingest_sessions as ing
+    msg = {
+        "role": "assistant",
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 200,
+            "cache_creation_input_tokens": 50,
+            "cache_read_input_tokens": 25,
+        },
+    }
+    # 100 + 200 + 50 + 25 = 375
+    assert ing._per_message_total(msg) == 375
+
+
+def test_per_message_total_handles_missing_usage():
+    import ingest_sessions as ing
+    assert ing._per_message_total({"role": "user"}) is None
+    assert ing._per_message_total({"role": "assistant", "usage": None}) is None
+    assert ing._per_message_total({"role": "assistant", "usage": "weird"}) is None
+
+
+def test_sum_usage_aggregates_across_assistant_entries_only():
+    import ingest_sessions as ing
+    entries = [
+        {"message": {"role": "user"}},  # no usage block
+        {"message": {"role": "assistant",
+                     "usage": {"input_tokens": 10, "output_tokens": 20}}},
+        {"message": {"role": "assistant",
+                     "usage": {"input_tokens": 5,
+                               "cache_creation_input_tokens": 3,
+                               "output_tokens": 7}}},
+        {"no_message_key": True},
+    ]
+    in_, out = ing._sum_usage(entries)
+    assert in_ == 10 + 5 + 3   # cache_creation counts as input
+    assert out == 20 + 7
+
+
+# ── Repair: parse_jsonl ──────────────────────────────────────────────────────
+def test_parse_jsonl_extracts_cwd_session_id_and_tokens(tmp_path):
+    import repair_conversations as rep
+
+    f = tmp_path / "session.jsonl"
+    f.write_text(
+        "\n".join([
+            json.dumps({"type": "user", "sessionId": "abc-123",
+                        "cwd": "/Users/me/repo",
+                        "message": {"role": "user", "content": "hi"}}),
+            json.dumps({"type": "assistant", "sessionId": "abc-123",
+                        "message": {"role": "assistant",
+                                    "usage": {"input_tokens": 10,
+                                              "output_tokens": 5,
+                                              "cache_read_input_tokens": 2}}}),
+            "",  # blank line tolerated
+            "{not valid json",  # malformed line tolerated
+            json.dumps({"type": "assistant",
+                        "message": {"role": "assistant",
+                                    "usage": {"input_tokens": 1, "output_tokens": 1}}}),
+        ]),
+        encoding="utf-8",
+    )
+    cwd, t_in, t_out, sid = rep.parse_jsonl(f)
+    assert cwd == "/Users/me/repo"
+    assert sid == "abc-123"
+    # 10 + 2 (cache_read) + 1 = 13 input
+    assert t_in == 13
+    # 5 + 1 = 6 output
+    assert t_out == 6
+
+
+def test_parse_jsonl_missing_file_returns_empty():
+    import repair_conversations as rep
+    cwd, t_in, t_out, sid = rep.parse_jsonl(Path("/nonexistent/path.jsonl"))
+    assert (cwd, t_in, t_out, sid) == (None, 0, 0, None)
+
+
+# ── Repair: repair_session ───────────────────────────────────────────────────
+def test_repair_session_aggregates_across_files(tmp_path, monkeypatch):
+    import repair_conversations as rep
+
+    parent = tmp_path / "parent.jsonl"
+    parent.write_text(
+        json.dumps({"type": "user", "sessionId": "s1",
+                    "cwd": "/Users/me/repo",
+                    "message": {"role": "assistant",
+                                "usage": {"input_tokens": 100, "output_tokens": 50}}}),
+        encoding="utf-8",
+    )
+    sub = tmp_path / "subagent-x.jsonl"
+    sub.write_text(
+        json.dumps({"sessionId": "s1",
+                    "message": {"role": "assistant",
+                                "usage": {"input_tokens": 200, "output_tokens": 75}}}),
+        encoding="utf-8",
+    )
+
+    conn = _FakeConn()
+    # Lookup row: id=42, current path is wrong, tokens are zero.
+    conn.push(_FakeCursor(row=(42, "/wrong/path", 0, 0)))
+    # Update cursor.
+    conn.push(_FakeCursor())
+
+    res = rep.repair_session(conn, session_id="s1",
+                             file_paths=[str(parent), str(sub)],
+                             dry_run=False)
+    assert res["status"] == "updated"
+    assert res["id"] == 42
+    assert res["changes"]["project_path"] == ("/wrong/path", "/Users/me/repo")
+    # 100 + 200 = 300 in; 50 + 75 = 125 out
+    assert res["changes"]["token_count_in"] == (0, 300)
+    assert res["changes"]["token_count_out"] == (0, 125)
+    assert conn.committed == 1
+
+
+def test_repair_session_dry_run_does_not_write(tmp_path):
+    import repair_conversations as rep
+
+    f = tmp_path / "s.jsonl"
+    f.write_text(
+        json.dumps({"sessionId": "s2", "cwd": "/x",
+                    "message": {"role": "assistant",
+                                "usage": {"input_tokens": 1, "output_tokens": 1}}}),
+        encoding="utf-8",
+    )
+    conn = _FakeConn()
+    conn.push(_FakeCursor(row=(7, None, 0, 0)))
+
+    res = rep.repair_session(conn, session_id="s2",
+                             file_paths=[str(f)], dry_run=True)
+    assert res["status"] == "would-update"
+    assert conn.committed == 0
+
+
+def test_repair_session_no_change_when_already_correct(tmp_path):
+    import repair_conversations as rep
+
+    f = tmp_path / "s.jsonl"
+    f.write_text(
+        json.dumps({"sessionId": "s3", "cwd": "/already/correct",
+                    "message": {"role": "assistant",
+                                "usage": {"input_tokens": 100, "output_tokens": 50}}}),
+        encoding="utf-8",
+    )
+    conn = _FakeConn()
+    conn.push(_FakeCursor(row=(8, "/already/correct", 100, 50)))
+
+    res = rep.repair_session(conn, session_id="s3",
+                             file_paths=[str(f)], dry_run=False)
+    assert res["status"] == "no-change"
+    assert conn.committed == 0
+
+
+def test_repair_session_skipped_when_row_missing(tmp_path):
+    import repair_conversations as rep
+
+    f = tmp_path / "s.jsonl"
+    f.write_text(
+        json.dumps({"sessionId": "missing", "cwd": "/x",
+                    "message": {"role": "user", "content": "hi"}}),
+        encoding="utf-8",
+    )
+    conn = _FakeConn()
+    conn.push(_FakeCursor(row=None))
+
+    res = rep.repair_session(conn, session_id="missing",
+                             file_paths=[str(f)], dry_run=False)
+    assert res["status"] == "skipped"
+    assert res["reason"] == "row-not-found"
+
+
+def test_repair_session_skipped_when_no_jsonl_readable():
+    import repair_conversations as rep
+    conn = _FakeConn()
+    res = rep.repair_session(conn, session_id="absent",
+                             file_paths=["/no/such/file"], dry_run=False)
+    assert res["status"] == "skipped"
+    assert res["reason"] == "no-readable-jsonl"

--- a/throughline/cli.py
+++ b/throughline/cli.py
@@ -209,6 +209,16 @@ def cmd_backfill_projects(args: argparse.Namespace) -> int:
     return _call_script_main("backfill_projects", passthrough)
 
 
+def cmd_repair_conversations(args: argparse.Namespace) -> int:
+    """Re-read JSONL files and repair conversations.project_path / token counts."""
+    passthrough: list[str] = []
+    if args.dry_run:
+        passthrough.append("--dry-run")
+    if args.limit is not None:
+        passthrough += ["--limit", str(args.limit)]
+    return _call_script_main("repair_conversations", passthrough)
+
+
 def cmd_status(args: argparse.Namespace) -> int:
     """Print a health snapshot of the memory DB.
 
@@ -398,6 +408,24 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--dry-run", action="store_true",
                    help="Preview what would be inserted; do not write.")
     p.set_defaults(func=cmd_backfill_projects)
+
+    # repair-conversations
+    p = sub.add_parser(
+        "repair-conversations",
+        help="Re-read JSONL files; fix project_path + token counts on existing rows.",
+        description=(
+            "Repairs two ingest bugs in existing conversations rows: "
+            "(1) project_path was hyphen-mangled (claude-memory-db → "
+            "claude/memory/db); (2) token_count_in / token_count_out were "
+            "never populated. Reads each file referenced via ingestion_log "
+            "and updates the matching row. Idempotent."
+        ),
+    )
+    p.add_argument("--dry-run", action="store_true",
+                   help="Preview changes; do not write.")
+    p.add_argument("--limit", type=int, default=None,
+                   help="Cap on number of files processed.")
+    p.set_defaults(func=cmd_repair_conversations)
 
     # status
     p = sub.add_parser(


### PR DESCRIPTION
## Summary

Two ingest correctness bugs fixed at the source, plus a one-shot repair script for already-ingested data, plus a token-formatting improvement in the GUI.

### What was wrong

1. **\`scripts/ingest_sessions.py:255\` mangled project_path.** It reconstructed a path from Claude Code's session-hash directory name by replacing every \`-\` with \`/\`. Any project with a hyphen in its name was silently destroyed: \`claude-memory-db\` → \`claude/memory/db\`, \`daily-mail-drafter\` → \`daily/mail/drafter\`, \`vse-net\` → \`vse/net\`. The literal repo name never appeared in the table, breaking every cross-table match.
2. **\`conversations.token_count_in\` / \`token_count_out\` were never populated.** The columns sat at NULL/0 even on long-lived sessions that had burned billions of tokens.

### What's fixed

- **Ingest** now reads the JSONL \`cwd\` field (Claude Code records it on every entry). The hash-replace logic stays as a fallback for older files that pre-date \`cwd\`.
- **Ingest** also aggregates each assistant message's \`usage\` block — \`input_tokens + cache_creation_input_tokens + cache_read_input_tokens\` for input, \`output_tokens\` for output — and stores per-conversation totals plus per-message \`messages.token_count\`.
- **\`scripts/repair_conversations.py\`** (\`throughline repair-conversations\`) re-reads each JSONL file via \`ingestion_log\`, **groups files by \`sessionId\`** so subagent JSONLs aggregate into the parent conversation rather than overwriting it (a subtle bug in the first version of this script — caught during dry-run when re-runs weren't idempotent), and UPDATEs in place. \`--dry-run\` and \`--limit N\` for safety.
- **Schema migration \`001_widen_conversation_token_counts.sql\`** — \`integer\` → \`bigint\`. Long-lived sessions including cache reads easily exceed 2 billion. The migration drops and re-creates the dependent \`v_conversation_stats\` view inside one transaction.
- **GUI \`fmt_count\` helper** turns large counts into \`1.2 M\` / \`5.70 B\` form for the Conversation detail Tokens-in / Tokens-out tiles. Below 10,000 the comma-grouped integer remains.

### Concrete impact on a real install

| | Before | After |
|---|---:|---:|
| \`claude-memory-db\` conversations matched by literal name | 0 | 2,287 |
| Total token_count_in summed across all conversations | 0 | 4.79 B |
| Total token_count_out | 0 | 20.9 M |
| Conversations repaired in one run | n/a | 3,146 in ~6 s |

### Test plan

- [x] \`pytest -q --ignore=tests/integration\` — **132 passing** (120 baseline + 12 new)
- [x] \`python3 -c \"import gui.app\"\` — clean import; \`fmt_count(1234567)\` → \`'1.2 M'\`
- [x] \`python3 -m throughline repair-conversations --dry-run --limit 50\` — sample output shows correct unmangling and token recovery
- [x] \`python3 -m throughline repair-conversations\` (twice) — second run reports zero updates (idempotent)
- [x] Schema migration applied locally; \`v_conversation_stats\` view recreated with same definition
- [x] Streamlit GUI rendered, Conversation detail tiles show \`74.5 M\` / \`349.0 K\` instead of raw digit blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)