### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-05-10
+
 ### Fixed
 
 - **`scripts/ingest_sessions.py` no longer mangles project paths.** It

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ See the full gallery below or browse [`docs/screenshots/`](docs/screenshots/).
   - **Strict project isolation.** Set `THROUGHLINE_PROJECT_SCOPE_STRICT=1` on the MCP server to refuse the `project=""` cross-project opt-out — every call must specify a project, enforcing data isolation between client engagements at policy level rather than convention.
 - **Context pre-loader hook** — `SessionStart` hook queries the DB for the current project and injects a short memory summary into the first system message.
 - **Scheduled automation** — macOS `launchd` plists for hourly ingest, daily extract, and daily backup. Linux users can wire the same scripts into systemd timers (units shipped under `systemd/`).
-- **Project-name fidelity** *(unreleased)* — Ingest reads the JSONL `cwd` field instead of reconstructing a path from the session-hash directory name (the old logic silently turned `claude-memory-db` into `claude/memory/db`). Token totals (`token_count_in` / `token_count_out`) are now read from each assistant message's `usage` block — they were unset before. Run `throughline repair-conversations` once to back-fill correct values on already-ingested rows; idempotent.
+- **Project-name fidelity** *(v0.3.0)* — Ingest reads the JSONL `cwd` field instead of reconstructing a path from the session-hash directory name (the old logic silently turned `claude-memory-db` into `claude/memory/db`). Token totals (`token_count_in` / `token_count_out`) are now read from each assistant message's `usage` block — they were unset before. Run `throughline repair-conversations` once to back-fill correct values on already-ingested rows; idempotent.
 
 ### UI
 
@@ -134,14 +134,29 @@ See the full gallery below or browse [`docs/screenshots/`](docs/screenshots/).
 - **CSV / Excel / PDF export** *(v0.2.0)* — Three download buttons above every list view (Conversations, Memory, Memory Health, Skills, Knowledge Graph entities, Projects, Prompts, every Search and Semantic-Search scope). CSV is UTF-8 with BOM; Excel via `openpyxl`; PDF via `reportlab` (landscape A4, repeated headers, alternating row backgrounds, document title and timestamp). Missing optional deps degrade gracefully — buttons disappear and the page shows a `pip install` hint. CSV is always available.
 - **Calendar view** — Sessions plotted on a month grid, click a day to drill down.
 - **SQL console** — Free-form SQL for power users.
-- **Memory Health card** *(unreleased)* — Four KPI tiles on the Dashboard (embedding coverage %, projects, contradictions outstanding, last reflection). Sourced from `throughline.status.collect_status` so the card, the `throughline status` CLI, and the `memory.stats` MCP tool can never drift apart.
-- **Projects page — sort, list, synthesised descriptions** *(unreleased)* — Sort selector (Recent activity / Created / Name / Memory volume / Status) and a **Cards | List** view toggle. Each row shows a synthesised activity blurb (`"42 chunks · 6 conversations · last active 2 weeks ago"`) when a manual description is empty.
-- **Project detail — seven tabs** *(unreleased)* — Opening a project drills into Overview, Memory, Conversations, Entities, Skills, Prompts, Reflections. Each tab carries a count and click-throughs to the artifact's own detail page; CSV/Excel/PDF export per tab.
-- **Compact token counts** *(unreleased)* — Token totals on the Conversation detail page render as `1.2 M` / `5.70 B` instead of raw 10-digit numbers.
+- **Memory Health card** *(v0.3.0)* — Four KPI tiles on the Dashboard (embedding coverage %, projects, contradictions outstanding, last reflection). Sourced from `throughline.status.collect_status` so the card, the `throughline status` CLI, and the `memory.stats` MCP tool can never drift apart.
+- **Projects page — sort, list, synthesised descriptions** *(v0.3.0)* — Sort selector (Recent activity / Created / Name / Memory volume / Status) and a **Cards | List** view toggle. Each row shows a synthesised activity blurb (`"42 chunks · 6 conversations · last active 2 weeks ago"`) when a manual description is empty.
+- **Project detail — seven tabs** *(v0.3.0)* — Opening a project drills into Overview, Memory, Conversations, Entities, Skills, Prompts, Reflections. Each tab carries a count and click-throughs to the artifact's own detail page; CSV/Excel/PDF export per tab.
+- **Compact token counts** *(v0.3.0)* — Token totals on the Conversation detail page render as `1.2 M` / `5.70 B` instead of raw 10-digit numbers.
 
 ---
 
 ## Quick Start
+
+> **Upgrading from v0.2.x?** v0.3.0 fixes two ingest bugs that left bad
+> data on disk: hyphenated project names were silently turned into
+> nested paths (`claude-memory-db` → `claude/memory/db`), and per-session
+> token counts were never populated. Run the one-shot repair once after
+> upgrading:
+>
+> ```bash
+> throughline repair-conversations           # idempotent; safe to re-run
+> ```
+>
+> On a real install this typically corrects ~3,000 rows in a few seconds
+> and recovers billions of input tokens that were unaccounted for.
+> Pre-existing manual edits (descriptions, contacts, decisions, status)
+> are never modified.
 
 ### Option A — Docker (one command, any platform)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "throughline"
-version = "0.2.0"
+version = "0.3.0"
 description = "Persistent long-term memory for Claude Code"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/throughline/__init__.py
+++ b/throughline/__init__.py
@@ -11,5 +11,5 @@ this package simply unifies them under a single ``throughline`` entrypoint.
 
 from __future__ import annotations
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

Cuts v0.3.0 — the largest release since v0.2.0 (PRs #16–#23 in this batch).

### Headline changes (full detail in CHANGELOG)

- **Project-name fidelity.** Ingest reads JSONL \`cwd\` instead of mangling the session-hash directory name. Hyphenated project names (\`claude-memory-db\`, \`daily-mail-drafter\`, …) are no longer silently destroyed.
- **Token totals.** \`conversations.token_count_in\` / \`token_count_out\` and \`messages.token_count\` are now populated from each assistant message's \`usage\` block — they were unset before. Schema migration widens the columns to \`bigint\` for long-lived sessions.
- **\`throughline repair-conversations\`.** One-shot repair for already-ingested rows. Idempotent; \`--dry-run\` and \`--limit\` for safety.
- **\`throughline status\` + \`memory.stats\` MCP tool + GUI Memory Health card.** Three surfaces, one \`collect_status()\` source of truth.
- **GUI Project detail.** Seven tabs (Overview / Memory / Conversations / Entities / Skills / Prompts / Reflections) with click-through to artifact detail and per-tab CSV/Excel/PDF export.
- **GUI Projects page.** Sort selector (Recent activity / Created / Name / Memory volume / Status), Cards | List view toggle, synthesised activity blurbs in place of empty descriptions.
- **\`throughline backfill-projects\`.** Populates the \`projects\` table from observed \`project_name\` values; idempotent.
- **Eval harness — \`--offline-stub\` and DB-free \`--dry-run\`** + a CI \`eval-smoke\` job that verifies the harness without DB or API keys.
- **Compact token formatting** (\`1.2 M\` / \`5.70 B\`) on conversation detail.

### Release machinery

Pushing the \`v0.3.0\` tag after this PR merges triggers \`.github/workflows/release.yml\` and publishes \`ghcr.io/mkupermann/throughline:v0.3.0\` (multi-arch).

### Upgrading

A callout in the Quick Start tells existing users to run \`throughline repair-conversations\` once. Idempotent; pre-existing manual edits on \`projects\` rows are never modified.

## Test plan

- [x] \`pytest -q --ignore=tests/integration\` — 132 passing
- [x] \`throughline version\` → \`throughline 0.3.0\`
- [x] CHANGELOG renders cleanly; \`[0.3.0] — 2026-05-10\` block is well-formed; fresh \`[Unreleased]\` is empty.
- [x] All \`*(unreleased)*\` markers in README replaced by \`*(v0.3.0)*\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)