### PR TITLE
PR 1/8 — Unify cross-tool positioning (README H1, pyproject, package docstring)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Throughline — Persistent longterm memory for your local AI tools
+# Throughline — one memory, every AI CLI on your laptop
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
@@ -11,7 +11,7 @@
 [![Last Commit](https://img.shields.io/github/last-commit/mkupermann/throughline)](https://github.com/mkupermann/throughline/commits/main)
 [![Live Demo](https://img.shields.io/badge/live%20demo-kupermann.com%2Fmemory%2F-b8532e.svg)](https://kupermann.com/memory/)
 
-> Claude Code, Codex, Hermes, Continue, Windsurf — they all start every new session as a blank page. Throughline keeps the thread across all of them: one searchable memory of your decisions, contacts and gotchas, on your own machine, regardless of which tool you happened to use that day.
+> **Every local AI CLI forgets between sessions. Throughline makes the lot of them stop forgetting — without sending your sessions anywhere.** One Postgres database on your laptop ingests session files from Claude Code, Codex, Hermes, Continue, Cline and Windsurf, extracts structured memory chunks, and feeds the unified history back to whichever tool you happen to be using next.
 
 <p align="center">
   <img src="docs/assets/hero.svg" alt="Throughline — the thread that survives every session" width="860">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "throughline"
 version = "0.3.0"
-description = "Persistent long-term memory for Claude Code"
+description = "One memory layer for every local AI CLI — auto-ingests sessions from Claude Code, Codex, Hermes, Continue, Cline and Windsurf into a single searchable Postgres+pgvector store."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }

--- a/throughline/__init__.py
+++ b/throughline/__init__.py
@@ -1,8 +1,11 @@
-"""Throughline — Persistent long-term memory for Claude Code.
+"""Throughline — one memory layer for every local AI CLI.
 
-A local-first, self-reflecting memory database that ingests Claude Code JSONL
-sessions, extracts insights, and gives Claude its own memory to query across
-sessions.
+A local-first, self-reflecting memory database that ingests session files
+from Claude Code, OpenAI Codex CLI, Hermes Agent, Continue.dev, Cline and
+Windsurf into a shared Postgres+pgvector store, extracts structured memory
+chunks, and exposes the unified history back to any of them — as a Claude
+Code skill, an MCP server (any MCP-aware client), or raw context injected
+at session start.
 
 This package is a thin CLI wrapper around the scripts in the ``scripts/``
 directory of the source repository. The scripts remain directly executable;


### PR DESCRIPTION
## Why

The repo is mid-rebrand: README body sells **cross-tool memory**, but three
high-visibility surfaces still read as *'memory for Claude Code'*:

| Surface | Before | After |
|---------|--------|-------|
| README H1 | `Persistent longterm memory for your local AI tools` | `Throughline — one memory, every AI CLI on your laptop` |
| README pull-quote | Lists tools, no elevator pitch | `Every local AI CLI forgets between sessions. Throughline makes the lot of them stop forgetting — without sending your sessions anywhere.` |
| `pyproject.toml` description | `Persistent long-term memory for Claude Code` | Cross-tool framing, lists all 6 adapters incl. Cline |
| `throughline/__init__.py` docstring | "ingests Claude Code JSONL sessions" | Lists every supported adapter; mentions MCP + Claude Code skill + raw-context delivery paths |

Cline shipped in PR #8 but the README pull-quote and pyproject still listed five tools. Now consistent with the body.

## What this is NOT
- Not a code change. No public-API change. No behavior change.
- Not the README restructure / hero animation (that's PR 2/8).
- Not the docs/why-cross-tool.md or `mem0/Letta` comparison refinement (PR 7/8).

## Plan context

This is **PR 1 of an 8-PR sequence** to push Throughline from 7.5/10 to release-quality. Sequence (will be referenced in each follow-up):

1. ✅ positioning unification *(this PR)*
2. Hero animation + dark architecture SVG + README restructure
3. `throughline doctor` command
4. `throughline conflicts` cross-tool consistency report
5. Split gui/app.py into per-page modules
6. Semantic time-travel CLI + UI
7. mem0/Letta comparison + docs/why-cross-tool.md
8. Coverage gate + Alembic + lockfile + PyPI release

## Review checklist
- [x] README H1 reads as elevator pitch
- [x] pyproject description matches (so PyPI / search results read cross-tool)
- [x] Package docstring matches
- [x] Cline included everywhere the adapter list appears
- [x] Pull-quote voice matches existing body sections