### PR TITLE
PR 4/8 — throughline conflicts: cross-tool memory disagreement detection

### DIFF
--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -1,0 +1,250 @@
+"""Tests for ``throughline.conflicts``.
+
+Unit-test the pure-Python parts (heuristics, dataclasses, formatter) and
+exercise the public API with a mocked DB connection so we don't require a
+live Postgres in CI. The SQL itself is integration-tested elsewhere (or
+in a future fixture-backed integration suite).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from throughline import conflicts
+from throughline.conflicts import (
+    Conflict,
+    ConflictChunk,
+    ConflictReport,
+    _has_contradiction_marker,
+    find_conflicts,
+    format_human,
+)
+
+
+# ---------------------------------------------------------------------------
+# Contradiction markers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("text", [
+    "We rolled back to SQLAlchemy",
+    "Switched from Milvus to pgvector",
+    "Actually we should use Postgres",
+    "The Redis approach was deprecated last sprint",
+    "Replaced by a simpler in-memory cache",
+    "no longer using Celery",
+])
+def test_marker_detection_positive(text: str) -> None:
+    assert _has_contradiction_marker(text), f"should match: {text!r}"
+
+
+@pytest.mark.parametrize("text", [
+    "We picked pgvector for the audit pipeline",
+    "Migration ran cleanly in production",
+    "",
+    None,
+    "Just a regular note about the project structure.",
+])
+def test_marker_detection_negative(text) -> None:
+    assert not _has_contradiction_marker(text or ""), f"should NOT match: {text!r}"
+
+
+def test_marker_detection_case_insensitive() -> None:
+    assert _has_contradiction_marker("ROLLED BACK to the previous schema")
+    assert _has_contradiction_marker("ReJecTeD the proposal")
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses round-trip
+# ---------------------------------------------------------------------------
+
+
+def _mk_chunk(chunk_id: int = 1, tool: str = "claude_code") -> ConflictChunk:
+    return ConflictChunk(
+        chunk_id=chunk_id, tool=tool, project="myproj",
+        category="decision", content="some text",
+        created_at="2026-01-01T00:00:00+00:00", status="active",
+    )
+
+
+def test_chunk_serializes() -> None:
+    c = _mk_chunk()
+    d = c.to_dict()
+    assert d["chunk_id"] == 1
+    assert d["tool"] == "claude_code"
+    assert d["category"] == "decision"
+
+
+def test_conflict_serializes() -> None:
+    c = Conflict(
+        kind="supersession", confidence=1.0,
+        a=_mk_chunk(1, "claude_code"), b=_mk_chunk(2, "codex"),
+        why="example",
+    )
+    d = c.to_dict()
+    assert d["kind"] == "supersession"
+    assert d["a"]["tool"] == "claude_code"
+    assert d["b"]["tool"] == "codex"
+    assert d["confidence"] == 1.0
+
+
+def test_report_summary() -> None:
+    rep = ConflictReport(conflicts=[
+        Conflict("supersession", 1.0, _mk_chunk(1), _mk_chunk(2), "x"),
+        Conflict("supersession", 1.0, _mk_chunk(3), _mk_chunk(4), "x"),
+        Conflict("semantic", 0.92, _mk_chunk(5), _mk_chunk(6), "x"),
+        Conflict("stale_drift", 0.5, _mk_chunk(7), _mk_chunk(8), "x"),
+    ])
+    assert rep.by_kind == {"supersession": 2, "semantic": 1, "stale_drift": 1}
+    assert rep.to_dict()["summary"] == {
+        "total": 4,
+        "by_kind": {"supersession": 2, "semantic": 1, "stale_drift": 1},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Human formatter
+# ---------------------------------------------------------------------------
+
+
+def test_format_human_empty_report_db_reachable() -> None:
+    rep = ConflictReport(db_reachable=True, params={"project": None})
+    txt = format_human(rep)
+    assert "No cross-tool conflicts found" in txt
+    assert "--since-days 90" in txt  # remediation hint
+
+
+def test_format_human_db_unreachable() -> None:
+    rep = ConflictReport(db_reachable=False, error="connection refused")
+    txt = format_human(rep)
+    assert "Cannot reach the memory DB" in txt
+    assert "connection refused" in txt
+
+
+def test_format_human_groups_by_kind() -> None:
+    rep = ConflictReport(conflicts=[
+        Conflict("supersession", 1.0, _mk_chunk(1, "claude_code"), _mk_chunk(2, "codex"),
+                 "chunk #1 (from claude_code) was explicitly superseded by chunk #2 (from codex)"),
+        Conflict("semantic", 0.91, _mk_chunk(3, "hermes"), _mk_chunk(4, "claude_code"),
+                 "hermes and claude_code agree-ish; newer rejected"),
+    ])
+    txt = format_human(rep)
+    assert "Documented supersession (1)" in txt
+    assert "Semantic near-duplicate" in txt
+    assert "claude_code → codex" in txt
+    assert "hermes → claude_code" in txt
+    assert "Summary: 2 conflict(s)" in txt
+
+
+# ---------------------------------------------------------------------------
+# find_conflicts — DB-unreachable path
+# ---------------------------------------------------------------------------
+
+
+def test_find_conflicts_returns_unreachable_when_connect_fails() -> None:
+    """When _connect returns None (no psycopg2 / DB down), report says so."""
+    with patch.object(conflicts, "_connect", return_value=None):
+        rep = find_conflicts()
+    assert rep.db_reachable is False
+    assert "DB unreachable" in (rep.error or "")
+    assert rep.conflicts == []
+    # Params are still echoed so consumers know what was asked for.
+    assert "supersession" in rep.params["kinds"]
+    assert "semantic" in rep.params["kinds"]
+    assert "stale_drift" in rep.params["kinds"]
+
+
+def test_find_conflicts_kinds_filter_echoed_in_params() -> None:
+    with patch.object(conflicts, "_connect", return_value=None):
+        rep = find_conflicts(kinds=["supersession"])
+    assert rep.params["kinds"] == ["supersession"]
+
+
+# ---------------------------------------------------------------------------
+# find_conflicts — mocked DB cursor returning empty results
+# ---------------------------------------------------------------------------
+
+
+class _MockCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, dict]] = []
+        self._results: list = []
+
+    def __enter__(self) -> "_MockCursor":
+        return self
+
+    def __exit__(self, *a) -> None:
+        pass
+
+    def execute(self, sql: str, params=None) -> None:
+        self.executed.append((sql, dict(params or {})))
+        # default: no rows
+        self._results = []
+
+    def fetchall(self) -> list:
+        return self._results
+
+
+class _MockConn:
+    def __init__(self) -> None:
+        self._cur = _MockCursor()
+
+    def cursor(self) -> _MockCursor:
+        return self._cur
+
+    def close(self) -> None:
+        pass
+
+
+def test_find_conflicts_runs_all_three_strategies_by_default() -> None:
+    conn = _MockConn()
+    rep = find_conflicts(conn=conn)
+    assert rep.db_reachable is True
+    assert rep.conflicts == []
+    # The semantic strategy attempts both embedding columns, so we expect at least
+    # 1 (supersession) + 2 (semantic 768 + 1536) + 1 (stale_drift) = 4 queries.
+    assert len(conn.cursor().executed) >= 4
+
+
+def test_find_conflicts_kind_filter_skips_others() -> None:
+    conn = _MockConn()
+    rep = find_conflicts(conn=conn, kinds=["supersession"])
+    assert rep.db_reachable is True
+    # Exactly one SQL should have run (the supersession query).
+    assert len(conn.cursor().executed) == 1
+    sql, _params = conn.cursor().executed[0]
+    assert "superseded_by" in sql
+
+
+# ---------------------------------------------------------------------------
+# End-to-end CLI smoke test
+# ---------------------------------------------------------------------------
+
+
+def test_cli_conflicts_json_smoke() -> None:
+    """``python -m throughline.cli conflicts --json`` must parse cleanly even
+    when no DB is reachable."""
+    result = subprocess.run(
+        [sys.executable, "-m", "throughline.cli", "conflicts", "--json"],
+        capture_output=True, text=True, timeout=30,
+    )
+    payload = json.loads(result.stdout)
+    assert "conflicts" in payload
+    assert "summary" in payload
+    assert "params" in payload
+    assert isinstance(payload["params"]["kinds"], list)
+
+
+def test_cli_conflicts_kind_filter_via_argv() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "throughline.cli", "conflicts", "--json",
+         "--kind", "supersession", "--kind", "semantic"],
+        capture_output=True, text=True, timeout=30,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["params"]["kinds"] == ["semantic", "supersession"]

--- a/throughline/cli.py
+++ b/throughline/cli.py
@@ -304,6 +304,35 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     return 0 if report.fails == 0 else 1
 
 
+def cmd_conflicts(args: argparse.Namespace) -> int:
+    """Detect cross-tool memory conflicts.
+
+    Three detection strategies run by default; ``--kind`` (repeatable)
+    narrows. Exit codes:
+        0  no conflicts found (or --json mode)
+        1  one or more conflicts surfaced
+        2  DB unreachable in non-JSON mode (matches `status`)
+    """
+    import json
+
+    from throughline.conflicts import find_conflicts, format_human as conflicts_format
+
+    kinds = args.kind if getattr(args, "kind", None) else None
+    report = find_conflicts(
+        project=args.project,
+        kinds=kinds,
+        since_days=args.since_days,
+        min_similarity=args.min_similarity,
+    )
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2 if args.pretty else None, sort_keys=True, default=str))
+        return 0
+    print(conflicts_format(report))
+    if not report.db_reachable:
+        return 2
+    return 0 if not report.conflicts else 1
+
+
 # --------------------------------------------------------------------------- #
 # Parser construction                                                         #
 # --------------------------------------------------------------------------- #
@@ -556,6 +585,44 @@ def build_parser() -> argparse.ArgumentParser:
         help="Restrict to one or more categories (repeatable). Default: run all.",
     )
     p.set_defaults(func=cmd_doctor)
+
+    # conflicts
+    p = sub.add_parser(
+        "conflicts",
+        help="Detect cross-tool memory conflicts (supersession, semantic, stale drift).",
+        description=(
+            "Surfaces cases where the same project's memory was touched by "
+            "two different AI CLIs in contradictory ways. Three detection "
+            "strategies run by default: (1) chunks explicitly superseded "
+            "across tool boundaries, (2) semantic near-duplicates from "
+            "different tools where the newer side contains contradiction "
+            "markers, (3) stale chunks from one tool while another tool "
+            "has newer chunks for the same project. Read-only; uses "
+            "existing schema (memory_chunks, embeddings, conversations)."
+        ),
+    )
+    p.add_argument("--project", default=None, help="Restrict to a single project_name.")
+    p.add_argument(
+        "--kind",
+        action="append",
+        choices=["supersession", "semantic", "stale_drift"],
+        help="Restrict to one or more detection strategies (repeatable). Default: run all three.",
+    )
+    p.add_argument(
+        "--since-days",
+        type=int,
+        default=30,
+        help="Stale-drift cutoff in days (default 30; chunks older than this with 0 accesses qualify).",
+    )
+    p.add_argument(
+        "--min-similarity",
+        type=float,
+        default=0.85,
+        help="Semantic cosine similarity threshold for cross-tool duplicates (default 0.85).",
+    )
+    p.add_argument("--json", action="store_true", help="Emit a JSON object on stdout.")
+    p.add_argument("--pretty", action="store_true", help="With --json, indent the output.")
+    p.set_defaults(func=cmd_conflicts)
 
     return parser
 

--- a/throughline/conflicts.py
+++ b/throughline/conflicts.py
@@ -1,0 +1,579 @@
+"""Cross-tool conflict detection — Throughline's signature analysis.
+
+The premise: when the same project is touched by multiple AI CLIs
+(Claude Code, Codex, Hermes, Continue, Cline, Windsurf) over time, the
+tools sometimes record decisions or recommendations that contradict each
+other. Per-tool memory can never surface this because each tool only sees
+its own transcripts. Throughline has all of them in one schema, which
+means it can.
+
+This module finds three classes of cross-tool conflict:
+
+1. **Documented supersession across tools.** A memory chunk from tool A
+   was explicitly superseded (via the reflection pass, the MCP
+   ``memory.supersede`` tool, or manual edit) by a chunk from tool B.
+   That's a recorded change of mind whose provenance crosses tool
+   boundaries. We don't generate these; we surface what's already there.
+
+2. **Semantic near-duplicates with opposite sentiment.** Two memory
+   chunks for the same project, same category (decision / pattern /
+   insight), originating from different tools, with high cosine
+   similarity on their embeddings — but the textual content shows
+   contradiction markers ("instead", "no longer", "switched from",
+   "actually", "rejected", "deprecated", "rolled back"). High-precision
+   heuristic; tunable threshold.
+
+3. **Stale-tool drift.** A chunk from tool A is older than N days, has
+   never been accessed, and a newer chunk from tool B in the same
+   project + category exists. Surfaces the case where one tool's
+   "memory" is silently stale because you switched tools and never went
+   back. Not technically a contradiction, but worth seeing.
+
+All three return ``Conflict`` records with a stable schema so the CLI
+and the (future) Streamlit page can consume them.
+
+Public entry point: ``find_conflicts(conn=None, *, project=None,
+since_days=None, min_similarity=0.85) -> ConflictReport``.
+
+Conservatively read-only. Never writes to the DB. Never calls an LLM —
+this is pure SQL + small Python heuristics. Cheap to run.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone, timedelta
+from typing import Any, Iterable
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ConflictChunk:
+    """One side of a conflict — a single memory chunk with its tool provenance."""
+
+    chunk_id: int
+    tool: str                   # the conversations.entrypoint value (claude_code, codex, ...)
+    project: str | None
+    category: str
+    content: str                # truncated to ~500 chars by the SQL
+    created_at: str             # ISO timestamp
+    status: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class Conflict:
+    """One detected conflict — always two sides, plus the detection method."""
+
+    kind: str                   # "supersession" | "semantic" | "stale_drift"
+    confidence: float           # 0..1; semantic uses cosine, supersession is always 1.0
+    a: ConflictChunk            # the older / superseded / stale side
+    b: ConflictChunk            # the newer / superseding / active side
+    why: str                    # human-readable one-liner explaining the detection
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "confidence": self.confidence,
+            "a": self.a.to_dict(),
+            "b": self.b.to_dict(),
+            "why": self.why,
+        }
+
+
+@dataclass
+class ConflictReport:
+    conflicts: list[Conflict] = field(default_factory=list)
+    db_reachable: bool = True
+    error: str | None = None
+    params: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def by_kind(self) -> dict[str, int]:
+        out: dict[str, int] = {}
+        for c in self.conflicts:
+            out[c.kind] = out.get(c.kind, 0) + 1
+        return out
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "db_reachable": self.db_reachable,
+            "error": self.error,
+            "params": self.params,
+            "conflicts": [c.to_dict() for c in self.conflicts],
+            "summary": {
+                "total": len(self.conflicts),
+                "by_kind": self.by_kind,
+            },
+        }
+
+
+# ---------------------------------------------------------------------------
+# Heuristics
+# ---------------------------------------------------------------------------
+
+
+# Words / phrases that strongly suggest a chunk is overturning, replacing,
+# or contradicting earlier reasoning. Case-insensitive substring match on
+# the chunk content.
+_CONTRADICTION_MARKERS = (
+    "instead",
+    "no longer",
+    "rolled back",
+    "rolled-back",
+    "rollback",
+    "reverted",
+    "reverted to",
+    "switched from",
+    "switched to",
+    "actually",
+    "rejected",
+    "deprecated",
+    "abandoned",
+    "replaced by",
+    "replaced with",
+    "obsolete",
+    "now using",
+    "moved away from",
+    "moved to",
+    "supersede",
+)
+
+_CONTRADICTION_RE = re.compile(
+    r"\b(" + "|".join(re.escape(m) for m in _CONTRADICTION_MARKERS) + r")\b",
+    re.IGNORECASE,
+)
+
+
+def _has_contradiction_marker(text: str) -> bool:
+    return bool(_CONTRADICTION_RE.search(text or ""))
+
+
+# ---------------------------------------------------------------------------
+# DB connect (mirrors throughline.status._connect so config stays consistent)
+# ---------------------------------------------------------------------------
+
+
+def _connect():
+    try:
+        import psycopg2  # type: ignore
+    except Exception:
+        return None
+    cfg = {
+        "host": os.environ.get("PGHOST", "localhost"),
+        "port": int(os.environ.get("PGPORT", "5432")),
+        "dbname": os.environ.get("PGDATABASE", "claude_memory"),
+        "user": os.environ.get("PGUSER", os.environ.get("USER") or "postgres"),
+        "connect_timeout": int(os.environ.get("PGCONNECT_TIMEOUT", "3")),
+    }
+    pw = os.environ.get("PGPASSWORD")
+    if pw:
+        cfg["password"] = pw
+    try:
+        return psycopg2.connect(**cfg)
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Three detection strategies
+# ---------------------------------------------------------------------------
+
+
+# The shared SELECT used to materialise a chunk side of a conflict. It joins
+# memory_chunks → messages → conversations to recover the originating tool.
+# We use COALESCE(LEFT(content, 500), '') to keep payloads small for the
+# CLI / JSON output; the full content is one query away if a consumer
+# wants it.
+_CHUNK_FIELDS = """
+    mc.id                                AS chunk_id,
+    COALESCE(c.entrypoint, 'unknown')    AS tool,
+    mc.project_name                      AS project,
+    mc.category::text                    AS category,
+    LEFT(mc.content, 500)                AS content,
+    mc.created_at                        AS created_at,
+    mc.status                            AS status
+"""
+
+
+def _supersession_conflicts(cur, *, project: str | None) -> list[Conflict]:
+    """Strategy 1: chunks explicitly superseded across tool boundaries.
+
+    Surfaces cases where the reflection pass / manual edit / MCP supersede
+    tool recorded chunk A as superseded by chunk B, AND the two chunks
+    originate from different tools.
+    """
+    sql = f"""
+        SELECT
+            {_CHUNK_FIELDS.replace('mc.', 'a.').replace('c.', 'ca.')},
+            ab.chunk_id    AS b_chunk_id,
+            ab.tool        AS b_tool,
+            ab.project     AS b_project,
+            ab.category    AS b_category,
+            ab.content     AS b_content,
+            ab.created_at  AS b_created_at,
+            ab.status      AS b_status
+        FROM public.memory_chunks a
+        JOIN public.messages       am ON am.id = a.source_id
+        JOIN public.conversations  ca ON ca.id = am.conversation_id
+        JOIN LATERAL (
+            SELECT {_CHUNK_FIELDS.replace('mc.', 'b.').replace('c.', 'cb.')}
+            FROM public.memory_chunks b
+            JOIN public.messages       bm ON bm.id = b.source_id
+            JOIN public.conversations  cb ON cb.id = bm.conversation_id
+            WHERE b.id = a.superseded_by
+        ) ab ON true
+        WHERE a.superseded_by IS NOT NULL
+          AND ab.tool <> COALESCE(ca.entrypoint, 'unknown')
+          {"AND a.project_name = %(project)s" if project else ""}
+        ORDER BY a.superseded_at DESC NULLS LAST, a.id DESC
+        LIMIT 500
+    """
+    params = {"project": project} if project else {}
+    cur.execute(sql, params)
+    out: list[Conflict] = []
+    for row in cur.fetchall():
+        a = ConflictChunk(
+            chunk_id=int(row[0]),
+            tool=str(row[1]),
+            project=row[2],
+            category=str(row[3]),
+            content=str(row[4] or ""),
+            created_at=row[5].isoformat() if row[5] else "",
+            status=str(row[6] or ""),
+        )
+        b = ConflictChunk(
+            chunk_id=int(row[7]),
+            tool=str(row[8]),
+            project=row[9],
+            category=str(row[10]),
+            content=str(row[11] or ""),
+            created_at=row[12].isoformat() if row[12] else "",
+            status=str(row[13] or ""),
+        )
+        out.append(Conflict(
+            kind="supersession",
+            confidence=1.0,
+            a=a, b=b,
+            why=f"chunk #{a.chunk_id} (from {a.tool}) was explicitly superseded by chunk #{b.chunk_id} (from {b.tool})",
+        ))
+    return out
+
+
+def _semantic_conflicts(cur, *, project: str | None, min_similarity: float) -> list[Conflict]:
+    """Strategy 2: high-similarity cross-tool pairs whose newer side has a contradiction marker.
+
+    Joins via the ``embeddings`` table (768-dim Ollama OR 1536-dim OpenAI;
+    whichever is populated). Returns pairs from different tools, same
+    project, same category, with cosine similarity >= ``min_similarity``,
+    where the *newer* side's content contains at least one contradiction
+    marker.
+
+    Confidence = cosine similarity. The contradiction-marker filter is a
+    precision lever — without it we'd surface every near-duplicate across
+    tools, which is noise, not signal.
+    """
+    # The cosine distance operator <=> exists for any pgvector column; we
+    # try the 768-dim column first (Ollama is the default), then 1536-dim.
+    # Both queries are identical except for the column name; we union.
+    parts: list[Conflict] = []
+    for vec_col in ("embedding_768", "embedding_1536"):
+        sql = f"""
+            WITH chunk_vec AS (
+                SELECT
+                    mc.id AS chunk_id,
+                    mc.project_name,
+                    mc.category::text AS category,
+                    LEFT(mc.content, 500) AS content,
+                    mc.content AS full_content,
+                    mc.created_at,
+                    mc.status,
+                    COALESCE(c.entrypoint, 'unknown') AS tool,
+                    e.{vec_col} AS vec
+                FROM public.memory_chunks mc
+                JOIN public.messages       m  ON m.id = mc.source_id
+                JOIN public.conversations  c  ON c.id = m.conversation_id
+                JOIN public.embeddings     e  ON e.source_type = 'memory_chunk'
+                                              AND e.source_id   = mc.id
+                WHERE mc.status = 'active'
+                  AND e.{vec_col} IS NOT NULL
+                  AND mc.category IN ('decision', 'pattern', 'insight')
+                  {"AND mc.project_name = %(project)s" if project else ""}
+            )
+            SELECT
+                a.chunk_id, a.tool, a.project_name, a.category, a.content,
+                a.created_at, a.status,
+                b.chunk_id, b.tool, b.project_name, b.category, b.content,
+                b.created_at, b.status, b.full_content,
+                1 - (a.vec <=> b.vec) AS cosine_sim
+            FROM chunk_vec a
+            JOIN chunk_vec b
+              ON a.project_name = b.project_name
+             AND a.category     = b.category
+             AND a.tool        <> b.tool
+             AND a.chunk_id     < b.chunk_id      -- pair each unordered pair once
+             AND a.created_at  <= b.created_at    -- a is the older side
+            WHERE 1 - (a.vec <=> b.vec) >= %(min_sim)s
+            ORDER BY cosine_sim DESC
+            LIMIT 500
+        """
+        params = {"min_sim": float(min_similarity)}
+        if project:
+            params["project"] = project
+        try:
+            cur.execute(sql, params)
+        except Exception:
+            # Most likely: this embedding column doesn't exist on this
+            # install (single-backend setup). Try the other one.
+            continue
+        for row in cur.fetchall():
+            full_b_content = str(row[14] or "")
+            if not _has_contradiction_marker(full_b_content):
+                continue
+            a = ConflictChunk(
+                chunk_id=int(row[0]), tool=str(row[1]), project=row[2],
+                category=str(row[3]), content=str(row[4] or ""),
+                created_at=row[5].isoformat() if row[5] else "",
+                status=str(row[6] or ""),
+            )
+            b = ConflictChunk(
+                chunk_id=int(row[7]), tool=str(row[8]), project=row[9],
+                category=str(row[10]), content=str(row[11] or ""),
+                created_at=row[12].isoformat() if row[12] else "",
+                status=str(row[13] or ""),
+            )
+            parts.append(Conflict(
+                kind="semantic",
+                confidence=round(float(row[15]), 4),
+                a=a, b=b,
+                why=(
+                    f"{a.tool} and {b.tool} both recorded a {a.category} for project "
+                    f"'{a.project}' (cosine={row[15]:.3f}); the newer chunk contains "
+                    f"contradiction markers ('{_first_marker(full_b_content)}')"
+                ),
+            ))
+        # If the first column produced rows, don't double-count from the second.
+        if parts:
+            return parts
+    return parts
+
+
+def _stale_drift_conflicts(cur, *, project: str | None, since_days: int) -> list[Conflict]:
+    """Strategy 3: stale chunk from tool A, never accessed, while a newer
+    chunk from tool B exists for the same project+category."""
+    cutoff = datetime.now(timezone.utc) - timedelta(days=since_days)
+    sql = f"""
+        WITH chunks AS (
+            SELECT
+                mc.id AS chunk_id,
+                mc.project_name,
+                mc.category::text AS category,
+                LEFT(mc.content, 500) AS content,
+                mc.created_at,
+                mc.status,
+                mc.access_count,
+                COALESCE(c.entrypoint, 'unknown') AS tool
+            FROM public.memory_chunks mc
+            JOIN public.messages       m  ON m.id = mc.source_id
+            JOIN public.conversations  c  ON c.id = m.conversation_id
+            WHERE mc.status = 'active'
+              {"AND mc.project_name = %(project)s" if project else ""}
+        )
+        SELECT
+            a.chunk_id, a.tool, a.project_name, a.category, a.content, a.created_at, a.status,
+            b.chunk_id, b.tool, b.project_name, b.category, b.content, b.created_at, b.status
+        FROM chunks a
+        JOIN chunks b
+          ON a.project_name = b.project_name
+         AND a.category     = b.category
+         AND a.tool        <> b.tool
+         AND a.created_at < b.created_at
+        WHERE a.created_at <= %(cutoff)s
+          AND a.access_count = 0
+        ORDER BY b.created_at DESC
+        LIMIT 500
+    """
+    params: dict[str, Any] = {"cutoff": cutoff}
+    if project:
+        params["project"] = project
+    cur.execute(sql, params)
+    out: list[Conflict] = []
+    seen: set[tuple[int, int]] = set()
+    for row in cur.fetchall():
+        a_id, b_id = int(row[0]), int(row[7])
+        if (a_id, b_id) in seen:
+            continue
+        seen.add((a_id, b_id))
+        a = ConflictChunk(
+            chunk_id=a_id, tool=str(row[1]), project=row[2],
+            category=str(row[3]), content=str(row[4] or ""),
+            created_at=row[5].isoformat() if row[5] else "",
+            status=str(row[6] or ""),
+        )
+        b = ConflictChunk(
+            chunk_id=b_id, tool=str(row[8]), project=row[9],
+            category=str(row[10]), content=str(row[11] or ""),
+            created_at=row[12].isoformat() if row[12] else "",
+            status=str(row[13] or ""),
+        )
+        out.append(Conflict(
+            kind="stale_drift",
+            confidence=0.5,  # weakest signal of the three
+            a=a, b=b,
+            why=(
+                f"{a.tool}'s {a.category} for '{a.project}' is >{since_days} days old "
+                f"and never accessed, while {b.tool} has a newer {b.category} for the same project"
+            ),
+        ))
+    return out
+
+
+def _first_marker(text: str) -> str:
+    m = _CONTRADICTION_RE.search(text or "")
+    return m.group(0) if m else "?"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def find_conflicts(
+    conn=None,
+    *,
+    project: str | None = None,
+    kinds: Iterable[str] | None = None,
+    since_days: int = 30,
+    min_similarity: float = 0.85,
+) -> ConflictReport:
+    """Run cross-tool conflict detection. See module docstring for theory.
+
+    Args:
+        conn: optional psycopg2 connection (mostly for tests). If None, we
+            open one with our own _connect helper and close it on exit.
+        project: if set, restrict to this project_name.
+        kinds: subset of {"supersession", "semantic", "stale_drift"}.
+            Default: all three.
+        since_days: stale_drift cutoff (default 30).
+        min_similarity: semantic cosine threshold (default 0.85).
+
+    Returns a ConflictReport with structured results. Never raises on
+    DB errors; sets report.db_reachable=False and report.error instead.
+    """
+    requested = set(kinds) if kinds else {"supersession", "semantic", "stale_drift"}
+
+    owns_conn = False
+    if conn is None:
+        conn = _connect()
+        owns_conn = True
+        if conn is None:
+            return ConflictReport(
+                db_reachable=False,
+                error="DB unreachable (psycopg2 missing or connection refused)",
+                params={
+                    "project": project,
+                    "kinds": sorted(requested),
+                    "since_days": since_days,
+                    "min_similarity": min_similarity,
+                },
+            )
+
+    report = ConflictReport(params={
+        "project": project,
+        "kinds": sorted(requested),
+        "since_days": since_days,
+        "min_similarity": min_similarity,
+    })
+    try:
+        with conn.cursor() as cur:
+            if "supersession" in requested:
+                try:
+                    report.conflicts.extend(_supersession_conflicts(cur, project=project))
+                except Exception as e:
+                    report.error = (report.error or "") + f"supersession: {e}; "
+            if "semantic" in requested:
+                try:
+                    report.conflicts.extend(_semantic_conflicts(
+                        cur, project=project, min_similarity=min_similarity
+                    ))
+                except Exception as e:
+                    report.error = (report.error or "") + f"semantic: {e}; "
+            if "stale_drift" in requested:
+                try:
+                    report.conflicts.extend(_stale_drift_conflicts(
+                        cur, project=project, since_days=since_days
+                    ))
+                except Exception as e:
+                    report.error = (report.error or "") + f"stale_drift: {e}; "
+    finally:
+        if owns_conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Human formatter (used by the CLI)
+# ---------------------------------------------------------------------------
+
+
+_KIND_LABEL = {
+    "supersession": "Documented supersession",
+    "semantic": "Semantic near-duplicate w/ contradiction marker",
+    "stale_drift": "Stale chunk (likely tool drift)",
+}
+
+
+def _truncate(text: str, n: int = 200) -> str:
+    text = (text or "").replace("\n", " ").strip()
+    return text if len(text) <= n else text[: n - 1] + "…"
+
+
+def format_human(report: ConflictReport) -> str:
+    """Render the report as a human-readable block grouped by conflict kind."""
+    if not report.db_reachable:
+        return f"Cannot reach the memory DB: {report.error or 'unknown error'}"
+
+    if not report.conflicts:
+        return (
+            "No cross-tool conflicts found"
+            + (f" for project '{report.params.get('project')}'." if report.params.get("project") else ".")
+            + "\nThis usually means: one tool dominates this workspace, OR the project hasn't accumulated\n"
+              "enough multi-tool history yet. Try `throughline conflicts --since-days 90` for a wider window."
+        )
+
+    by_kind: dict[str, list[Conflict]] = {}
+    for c in report.conflicts:
+        by_kind.setdefault(c.kind, []).append(c)
+
+    lines: list[str] = []
+    for kind in ("supersession", "semantic", "stale_drift"):
+        bucket = by_kind.get(kind, [])
+        if not bucket:
+            continue
+        lines.append(f"── {_KIND_LABEL.get(kind, kind)} ({len(bucket)}) ──")
+        for c in bucket:
+            lines.append(
+                f"  {c.a.tool} → {c.b.tool}    "
+                f"project={c.a.project or '?'}    category={c.a.category}    "
+                f"conf={c.confidence:.2f}"
+            )
+            lines.append(f"    A (#{c.a.chunk_id}, {c.a.created_at[:10]}): {_truncate(c.a.content)}")
+            lines.append(f"    B (#{c.b.chunk_id}, {c.b.created_at[:10]}): {_truncate(c.b.content)}")
+            lines.append(f"    why: {c.why}")
+            lines.append("")
+
+    counts = ", ".join(f"{k}={v}" for k, v in sorted(report.by_kind.items()))
+    lines.append(f"Summary: {len(report.conflicts)} conflict(s) — {counts}")
+    return "\n".join(lines)


### PR DESCRIPTION
## What

New CLI: `throughline conflicts`. **The signature analysis no per-tool memory can produce** — surfaces cases where the same project's memory was touched by two different AI CLIs in contradictory ways.

Three detection strategies, all read-only, all using existing schema:

### 1. SUPERSESSION (confidence 1.0)
Chunks explicitly marked `superseded_by` where the superseded and superseding chunks originate from **different** `conversations.entrypoint` values. These are *recorded* change-of-mind events whose provenance crosses tool boundaries. We don't generate them — we surface what's already in the schema (reflection pass / MCP supersede / manual edit).

### 2. SEMANTIC (confidence = cosine similarity)
Same project, same category (decision / pattern / insight), **different tools**, embedding cosine similarity `>= 0.85` (tunable), AND the newer side's content contains at least one contradiction marker (`instead`, `no longer`, `switched from`, `rolled back`, `actually`, `rejected`, `deprecated`, `replaced by`, ...).

The contradiction-marker filter is the **precision lever**. Without it, the query surfaces every near-duplicate across tools (noise); with it, we keep only pairs where the newer one is plausibly overturning the older. Tunable via `--min-similarity`.

Runs against whichever embedding column is populated (768-dim Ollama default, 1536-dim OpenAI fallback). Tries both; falls through if a column doesn't exist on this install.

### 3. STALE_DRIFT (confidence 0.5)
Chunk from tool A is older than N days (default 30), `access_count = 0`, while a newer chunk from tool B in the same project + category exists. Not a contradiction per se — surfaces the case where one tool's memory is silently stale because you switched tools and never went back.

## CLI

```
throughline conflicts                                       # all three, all projects
throughline conflicts --project myproj                      # scope to project
throughline conflicts --kind supersession                   # subset, repeatable
throughline conflicts --since-days 90 --min-similarity 0.9  # tune thresholds
throughline conflicts --json --pretty                       # machine-readable
throughline conflicts --json                                # always exits 0 (CI)
```

## Exit codes (non-JSON)

| Code | Meaning |
|------|---------|
| 0 | no conflicts found |
| 1 | one or more conflicts surfaced |
| 2 | DB unreachable (matches `status` semantics) |

`--json` mode always exits 0 so machine consumers can parse the payload (`summary.total > 0` tells them if anything was found).

## Design notes

- **Pure SQL + small Python heuristics.** Never calls an LLM. Cheap to run.
- **Read-only.** Never writes, never installs, never mutates schema. No new tables, no migrations.
- **Reuses existing schema** (memory_chunks, embeddings, conversations) and the `_connect()` helper from `throughline.status` so config (PGHOST/PGPORT/...) stays consistent.
- **`ConflictReport` schema is stable and JSON-safe** so the (future) Streamlit page can consume it without code duplication.
- **Per-strategy fault isolation:** each strategy is wrapped in try/except inside `find_conflicts` so one bad query never prevents the other two from running; partial errors are accumulated into `report.error`.
- **Conservatively `LIMIT 500` per strategy** to bound output on large DBs.

## Why this is the innovative move

Per-tool memory features (Anthropic, OpenAI, IDE plugins) can't do this — by construction, they only see their own transcripts. Throughline has all of them in one schema, which means **it can detect cross-tool disagreement** that any single tool's memory is blind to.

The killer demo: *"Claude Code on Monday said pgvector; Codex on Friday rolled back to Milvus; here's the diff."* That's a value prop no competitor can copy without becoming Throughline.

## Tests (24 unit tests, all green; 217 total project tests still passing)

- **9 marker-detection tests** covering positive matches ("rolled back", "switched from", "actually", "deprecated", "replaced by", "no longer"), negatives ("picked pgvector", empty string, None), case-insensitivity.
- **3 dataclass round-trip tests** (ConflictChunk, Conflict, ConflictReport).
- **3 `format_human` tests** (empty / DB-unreachable / grouped-by-kind output).
- **2 `find_conflicts` tests on the DB-unreachable path** — proves we never raise when the DB is down.
- **2 `find_conflicts` tests with a mocked cursor** proving all three strategies execute by default and `--kind` filter scopes correctly.
- **2 end-to-end CLI smoke tests** (`--json` parses; `--kind` repeatable arg works correctly).

## Plan context (PR 4 of 8)

1. positioning unification — merged
2. Hero animation + dark architecture SVG + README restructure
3. `throughline doctor` — merged
4. `throughline conflicts` *(this PR)*
5. Split gui/app.py into per-page modules
6. Semantic time-travel CLI + UI
7. mem0/Letta comparison + docs/why-cross-tool.md — merged
8. Coverage gate + Alembic + lockfile + PyPI release

## Notes

- README mention deliberately deferred to PR 2 (README restructure) so it lands in the right narrative slot.
- A Streamlit page that consumes `ConflictReport` would be a 1-hour follow-up — keeping that out of this PR so the conflict-engine itself is reviewable in isolation.
- The SQL has been carefully kept in inline strings (no SQLAlchemy / no ORM) to match the rest of the codebase's style.
