### PR TITLE
fix(adapter/claude_code): skip headless title-generator echo sessions

### DIFF
--- a/tests/test_adapter_claude_code.py
+++ b/tests/test_adapter_claude_code.py
@@ -139,6 +139,93 @@ class TestClaudeCodeAdapter:
         assert conv is not None
         assert conv.session_id == real_sid
 
+    def test_skips_title_generator_echo_sessions(self, tmp_path):
+        # Each headless `claude -p` call issued by scripts/generate_titles.py
+        # gets logged as its own Claude Code session. Without this filter the
+        # ingest re-imports them, producing hundreds of duplicate
+        # "Session-Titel-Generator" rows. The adapter must drop them.
+        sid = str(uuid.uuid4())
+        ts = datetime(2026, 1, 15, 10, 0, 0, tzinfo=timezone.utc).isoformat()
+        path = tmp_path / f"{sid}.jsonl"
+        prompt = (
+            "Du bekommst einen Auszug aus einer Claude Code Session. "
+            "Generiere einen prägnanten deutschen Titel (max 60 Zeichen) ..."
+        )
+        _write_jsonl(
+            path,
+            [
+                {
+                    "type": "user",
+                    "uuid": str(uuid.uuid4()),
+                    "isSidechain": False,
+                    "message": {"role": "user", "content": prompt},
+                    "timestamp": ts,
+                    "sessionId": sid,
+                    "cwd": "/repo/throughline",
+                },
+                {
+                    "type": "assistant",
+                    "uuid": str(uuid.uuid4()),
+                    "isSidechain": False,
+                    "message": {
+                        "role": "assistant",
+                        "model": "claude-sonnet-4-6",
+                        "content": [{"type": "text", "text": "Some title"}],
+                    },
+                    "timestamp": ts,
+                    "sessionId": sid,
+                },
+            ],
+        )
+
+        a = ClaudeCodeAdapter()
+        assert a.parse(path) is None
+
+    def test_does_not_skip_session_that_merely_mentions_generator(self, tmp_path):
+        # Only the *first* user message starting with the marker triggers the
+        # skip — sessions that quote the prompt later (e.g. debugging
+        # generate_titles.py) must still be ingested.
+        sid = str(uuid.uuid4())
+        ts = datetime(2026, 1, 15, 10, 0, 0, tzinfo=timezone.utc).isoformat()
+        path = tmp_path / f"{sid}.jsonl"
+        _write_jsonl(
+            path,
+            [
+                {
+                    "type": "user",
+                    "uuid": str(uuid.uuid4()),
+                    "isSidechain": False,
+                    "message": {
+                        "role": "user",
+                        "content": "Schau dir bitte scripts/generate_titles.py an.",
+                    },
+                    "timestamp": ts,
+                    "sessionId": sid,
+                    "cwd": "/repo/throughline",
+                },
+                {
+                    "type": "user",
+                    "uuid": str(uuid.uuid4()),
+                    "isSidechain": False,
+                    "message": {
+                        "role": "user",
+                        "content": (
+                            "Du bekommst einen Auszug aus einer Claude Code "
+                            "Session. Generiere einen prägnanten deutschen "
+                            "Titel — das ist der Prompt aus dem Script."
+                        ),
+                    },
+                    "timestamp": ts,
+                    "sessionId": sid,
+                },
+            ],
+        )
+
+        a = ClaudeCodeAdapter()
+        conv = a.parse(path)
+        assert conv is not None
+        assert conv.session_id == sid
+
     def test_discover_walks_per_project_subdirs(self, tmp_path, monkeypatch):
         # Claude Code stores ~/.claude/projects/<slug>/*.jsonl; the adapter
         # must enumerate sub-dirs, not flat-glob the root.

--- a/throughline/adapters/claude_code.py
+++ b/throughline/adapters/claude_code.py
@@ -17,6 +17,36 @@ from typing import Any, Iterable
 
 from .base import Adapter, NormalisedConversation, NormalisedMessage
 
+# Sessions whose first user message starts with this marker are headless
+# `claude -p ...` calls issued by scripts/generate_titles.py. Each such call is
+# itself logged as a Claude Code session, then re-ingested here — producing
+# hundreds of indistinguishable "Session-Titel-Generator" rows. Skip them at
+# the adapter boundary so they never enter the DB.
+_TITLE_GENERATOR_MARKER = (
+    "Du bekommst einen Auszug aus einer Claude Code Session. "
+    "Generiere einen prägnanten deutschen Titel"
+)
+
+
+def _is_title_generator_session(entries: list[dict[str, Any]]) -> bool:
+    for e in entries:
+        msg = e.get("message")
+        if not isinstance(msg, dict) or msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        text: str | None = None
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text = block.get("text")
+                    break
+        if text and text.lstrip().startswith(_TITLE_GENERATOR_MARKER):
+            return True
+        return False
+    return False
+
 
 def _load_legacy() -> Any:
     """Import scripts/ingest_sessions.py as a module without running its main()."""
@@ -68,6 +98,9 @@ class ClaudeCodeAdapter(Adapter):
 
         msg_entries = [e for e in entries if isinstance(e.get("message"), dict)]
         if not msg_entries:
+            return None
+
+        if _is_title_generator_session(msg_entries):
             return None
 
         # cwd from the JSONL is the authoritative project_path.


### PR DESCRIPTION
## Problem

`scripts/generate_titles.py` issues headless `claude -p <prompt>` calls to backfill missing conversation titles. Each call is itself logged by Claude Code as a new session under `~/.claude/projects/.../*.jsonl` and re-ingested on the next sync.

The first user message of every such session is the title-generator prompt itself, so the generator dutifully produces titles like "Session-Titel-Generator für Claude Code" — over and over. In a representative local DB, **164/213 conversations (~77%)** were these duplicates.

## Fix

Drop title-generator echo sessions at the adapter boundary. `ClaudeCodeAdapter.parse()` now returns `None` when the first user message starts with the well-known German marker prefix:

> "Du bekommst einen Auszug aus einer Claude Code Session. Generiere einen prägnanten deutschen Titel"

Only the *first* user message is inspected — sessions that merely quote the prompt later (e.g. when editing `generate_titles.py` itself) are still ingested.

## Test plan
- [x] `tests/test_adapter_claude_code.py::test_skips_title_generator_echo_sessions` — echo session returns `None`
- [x] `tests/test_adapter_claude_code.py::test_does_not_skip_session_that_merely_mentions_generator` — quote-later session still parsed
- [x] All 9 adapter tests pass