### PR TITLE
fix(gui,cli): make GUI importable under Streamlit + auto-load .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ PGUSER=$USER
 PGHOST=localhost
 PGPORT=5432
 PGDATABASE=claude_memory
+# Set PGPASSWORD when Postgres requires password auth — e.g. the bundled
+# docker-compose stack, whose default is below. Leave unset for local peer/
+# trust auth. The CLI and GUI load this .env automatically (real environment
+# variables and Docker-injected settings always take precedence).
+# PGPASSWORD=throughline_dev_password
 
 # ---------------------------------------------------------------------------
 # Optional: OpenAI for embeddings

--- a/gui/app.py
+++ b/gui/app.py
@@ -17,6 +17,22 @@ import psycopg2
 import psycopg2.extras
 import streamlit as st
 
+# ── Make `gui` importable no matter how this script is launched ──────────────
+# `streamlit run gui/app.py` only guarantees the script's own directory (gui/)
+# on sys.path — not the repo root. Older Streamlit releases also added the CWD,
+# which used to mask this; on current Streamlit the import below would raise
+# `ModuleNotFoundError: No module named 'gui'`. Put the repo root (gui/'s
+# parent) on the path first so `from gui.page_views import …` always resolves.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+# Honour a local .env (PGUSER / PGPASSWORD / …) when present. load_dotenv never
+# overrides real environment variables, so Docker-injected settings still win.
+from throughline.config import load_dotenv as _load_dotenv  # noqa: E402
+
+_load_dotenv()
+
 # ── Hand our live globals to gui/page_views/* so they can read st/q/page_header/…
 # without re-importing this module (re-import would re-run the sidebar widgets
 # and trip StreamlitDuplicateElementId). See gui/page_views/__init__.py for why we

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -90,3 +90,55 @@ class TestRepoRoot:
         root = config.repo_root()
         assert (root / "scripts").is_dir()
         assert (root / "pyproject.toml").is_file()
+
+
+class TestLoadDotenv:
+    def test_sets_vars_from_file(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("TL_TEST_KEY", raising=False)
+        env = tmp_path / ".env"
+        env.write_text("TL_TEST_KEY=hello\n")
+        applied = config.load_dotenv(env)
+        assert applied == {"TL_TEST_KEY": "hello"}
+        assert os.environ["TL_TEST_KEY"] == "hello"
+
+    def test_does_not_override_existing_env(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TL_TEST_KEY", "from-shell")
+        env = tmp_path / ".env"
+        env.write_text("TL_TEST_KEY=from-file\n")
+        applied = config.load_dotenv(env)
+        # Existing environment wins; the file value is not applied.
+        assert "TL_TEST_KEY" not in applied
+        assert os.environ["TL_TEST_KEY"] == "from-shell"
+
+    def test_override_true_replaces_existing(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TL_TEST_KEY", "from-shell")
+        env = tmp_path / ".env"
+        env.write_text("TL_TEST_KEY=from-file\n")
+        config.load_dotenv(env, override=True)
+        assert os.environ["TL_TEST_KEY"] == "from-file"
+
+    def test_ignores_comments_blanks_and_strips_export_and_quotes(self, monkeypatch, tmp_path):
+        for k in ("TL_A", "TL_B", "TL_C"):
+            monkeypatch.delenv(k, raising=False)
+        env = tmp_path / ".env"
+        env.write_text(
+            "# a comment\n"
+            "\n"
+            "export TL_A=plain\n"
+            'TL_B="quoted value"\n'
+            "TL_C='has=equals'\n"
+        )
+        applied = config.load_dotenv(env)
+        assert applied == {"TL_A": "plain", "TL_B": "quoted value", "TL_C": "has=equals"}
+
+    def test_missing_file_is_noop(self, tmp_path):
+        applied = config.load_dotenv(tmp_path / "does-not-exist.env")
+        assert applied == {}
+
+    def test_defaults_to_repo_root_dotenv(self, monkeypatch):
+        # With no path given it must resolve <repo_root>/.env. We only assert
+        # it runs without error and returns a dict (the repo ships a .env in
+        # dev; CI may not — both are acceptable).
+        monkeypatch.delenv("TL_TEST_KEY", raising=False)
+        applied = config.load_dotenv()
+        assert isinstance(applied, dict)

--- a/tests/test_gui_app_import_bootstrap.py
+++ b/tests/test_gui_app_import_bootstrap.py
@@ -1,0 +1,56 @@
+"""Regression test for ``gui/app.py``'s import-path bootstrap.
+
+Streamlit launches ``streamlit run gui/app.py`` with only the *script's*
+directory (``gui/``) guaranteed on ``sys.path`` — not the repo root. Older
+Streamlit releases also added the CWD, which masked the fact that
+``gui/app.py`` imports ``gui.page_views`` (a package that lives at the repo
+root and is deliberately excluded from the installed wheel). On Streamlit
+≥1.x this regressed into ``ModuleNotFoundError: No module named 'gui'``.
+
+``app.py`` must therefore put the repo root on ``sys.path`` *before* it
+imports ``gui.page_views``. This test reproduces Streamlit's launch path in a
+subprocess and asserts the real header of ``app.py`` resolves the import.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+APP_PY = ROOT / "gui" / "app.py"
+GUI_DIR = ROOT / "gui"
+
+
+def test_app_header_resolves_gui_package_without_repo_root_on_path(tmp_path):
+    src = APP_PY.read_text().splitlines()
+    # Take the file header up to and including the gui.page_views import — the
+    # bootstrap under test must live before that line for the import to work.
+    cut = next(i for i, line in enumerate(src) if "from gui.page_views import" in line)
+    header = "\n".join(src[: cut + 1])
+
+    prog = "\n".join(
+        [
+            "import sys, os",
+            # Mimic Streamlit: drop the repo root, then prepend the script's dir.
+            f"sys.path = [p for p in sys.path if os.path.realpath(p) != os.path.realpath({str(ROOT)!r})]",
+            f"sys.path.insert(0, {str(GUI_DIR)!r})",
+            f"exec(compile({header!r}, {str(APP_PY)!r}, 'exec'))",
+            "print('IMPORT_OK')",
+        ]
+    )
+
+    env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+    result = subprocess.run(
+        [sys.executable, "-c", prog],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),  # not the repo root, so CWD can't smuggle it onto the path
+        env=env,
+    )
+    assert "IMPORT_OK" in result.stdout, (
+        "gui/app.py failed to import gui.page_views when launched the way "
+        f"Streamlit launches it.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )

--- a/throughline/cli.py
+++ b/throughline/cli.py
@@ -21,7 +21,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from throughline import __version__
-from throughline.config import repo_root
+from throughline.config import load_dotenv, repo_root
 
 # --------------------------------------------------------------------------- #
 # Helpers                                                                     #
@@ -628,6 +628,10 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # Load a local .env (PGUSER / PGPASSWORD / …) before anything touches the
+    # DB config. Never overrides real environment variables, so shell- or
+    # Docker-provided settings still win.
+    load_dotenv()
     parser = build_parser()
     args = parser.parse_args(argv)
     handler: Callable[[argparse.Namespace], int] = args.func

--- a/throughline/config.py
+++ b/throughline/config.py
@@ -14,6 +14,45 @@ from shutil import which
 from typing import Any
 
 
+def load_dotenv(path: str | os.PathLike[str] | None = None, *, override: bool = False) -> dict[str, str]:
+    """Load ``KEY=VALUE`` pairs from a ``.env`` file into ``os.environ``.
+
+    Defaults to ``<repo_root>/.env``. Blank lines and ``#`` comments are
+    skipped, an optional leading ``export `` is stripped, and surrounding
+    single/double quotes are removed from the value. Existing environment
+    variables are left untouched unless ``override=True`` — so a value
+    exported in the shell (or injected by Docker) always wins over the file.
+
+    A missing file is a no-op. Returns the mapping of keys that were applied,
+    which makes the call testable and lets the CLI report what it loaded.
+    """
+    target = Path(path) if path is not None else repo_root() / ".env"
+    if not target.is_file():
+        return {}
+
+    applied: dict[str, str] = {}
+    for raw in target.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        key, sep, value = line.partition("=")
+        if not sep:
+            continue
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        if not key:
+            continue
+        if not override and key in os.environ:
+            continue
+        os.environ[key] = value
+        applied[key] = value
+    return applied
+
+
 def get_db_config() -> dict[str, Any]:
     """Return psycopg2 connection kwargs resolved from env vars.
 


### PR DESCRIPTION
## Problem

Two papercuts stopped a fresh local run of Throughline from working:

1. **GUI won't start.** `streamlit run gui/app.py` (and `throughline gui`) crashed with `ModuleNotFoundError: No module named 'gui'`. `app.py` imports `gui.page_views`, but Streamlit only puts the script's own directory (`gui/`) on `sys.path`, not the repo root. Older Streamlit releases also added the CWD, which masked this — on current Streamlit (1.57) it's a hard failure. `gui` is deliberately excluded from the installed wheel, so the editable install doesn't help either.
2. **CLI/GUI ignore `.env`.** `throughline status` reported `DB unreachable` even with a correct `.env`, because nothing loaded it — `get_db_config()` reads `os.environ`, and `PGUSER`/`PGPASSWORD` never got there. The user had to `export` the PG vars by hand every time.

## Fix

- `gui/app.py`: put the repo root on `sys.path` before importing `gui.page_views`, so every launch path resolves regardless of how Streamlit handles `sys.path`.
- `throughline/config.py`: add `load_dotenv()` — a dependency-free `.env` loader that **never overrides** real environment variables (so shell- and Docker-injected settings still win). A missing file is a no-op.
- Call `load_dotenv()` from the CLI `main()` and from the GUI startup.
- `.env.example`: document `PGPASSWORD` (the docker-compose stack needs it).

## Tests

- `tests/test_config.py::TestLoadDotenv` — sets vars, respects precedence, `override=True`, comment/blank/`export`/quote parsing, missing-file no-op.
- `tests/test_gui_app_import_bootstrap.py` — reproduces Streamlit's launch path in a subprocess (only `gui/` on `sys.path`, repo root removed) and asserts `app.py`'s real header resolves the `gui.page_views` import. Fails without the bootstrap, passes with it.

Full unit suite: **303 passed, 1 skipped** (pre-existing `mcp` skip). Verified end-to-end: with no PG env exported, `throughline status` → `DB reachable`, and `streamlit run gui/app.py` boots clean.