### PR TITLE
feat(generate-titles): rich whole-session descriptions + local Ollama backend

### DIFF
--- a/scripts/generate_titles.py
+++ b/scripts/generate_titles.py
@@ -1,16 +1,29 @@
 #!/usr/bin/env python3
 """
-Generiert prägnante Titel für alle Conversations die noch keinen haben.
-Nutzt Claude CLI (kein separater API-Key nötig).
+Erzeugt klare deutsche Beschreibungen für Conversations: Anfang, was gemacht
+wurde, was erreicht wurde.
+
+Anders als eine reine Titelzeile liest dieser Generator die ganze Session
+(Anfang, Mitte und Ende werden gesampelt, nicht nur die ersten Nachrichten),
+damit lange Sessions nicht nur über ihren Einstieg beschrieben werden.
+
+Backends, in dieser Reihenfolge bei ``--backend auto`` (Default):
+  1. Ollama (lokal, nichts verlässt den Rechner) — wenn ein Chat-Modell da ist.
+  2. Claude CLI (Fallback) — braucht das installierte ``claude``-Binary.
+Erzwingen mit ``--backend ollama`` bzw. ``--backend claude``.
 """
 from _bootstrap import use_venv  # noqa: E402
 use_venv()
 
 
+import json
 import os
+import re
 import subprocess
 import sys
 import time
+import urllib.error
+import urllib.request
 from typing import Any
 
 import psycopg2
@@ -22,7 +35,42 @@ DB: dict[str, Any] = {
     "port": int(os.environ.get("PGPORT", "5432")),
 }
 
+# ─── Tunables ──────────────────────────────────────────────────────────────
+MODEL = "sonnet"            # Claude model (fallback backend)
+MAX_PER_RUN = 50
+MAX_PREVIEW_CHARS = 6000    # transcript budget handed to the model
+MAX_MSG_CHARS = 500         # per-message truncation before sampling
+MAX_SUMMARY_CHARS = 800     # cap on the stored description
+SLEEP_CLAUDE = 1.5
+SLEEP_OLLAMA = 0.2
+TIMEOUT_CLAUDE = 60
+TIMEOUT_OLLAMA = 240        # local models are slower, especially on long input
 
+# Model-name fragments that mark an embedding model (never a chat model).
+EMBED_HINTS = ("embed", "nomic", "bge", "minilm", "gte", "mxbai")
+
+_THINK_RE = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
+
+PROMPT = """Du bekommst Auszüge aus einer Entwickler-Session mit einem KI-Assistenten. Bei langen Sessions sind nur Anfang, Mitte und Ende enthalten, die Markierungen zeigen wo Teile ausgelassen sind.
+
+Schreibe eine klare deutsche Beschreibung in zwei bis vier Sätzen, als ein Absatz, die drei Dinge abdeckt:
+1. Womit die Session begann, also Ausgangslage oder Ziel.
+2. Was gemacht wurde, also die wichtigsten Schritte, Technologien und Dateien.
+3. Was am Ende erreicht wurde, also Ergebnis oder Stand.
+
+Regeln:
+- Konkret und sachlich, nenne Technologien und Themen beim Namen.
+- Kein Vorwort wie "In dieser Session", keine Aufzählung, keine Anführungszeichen.
+- Ein zusammenhängender Absatz, deutscher Fließtext.
+
+Session-Auszüge:
+
+{TRANSCRIPT}
+
+Gib NUR die Beschreibung zurück, sonst nichts."""
+
+
+# ─── DB ──────────────────────────────────────────────────────────────────────
 def _connect() -> "psycopg2.extensions.connection":
     """Connect to PostgreSQL with a friendly error if the DB is unreachable."""
     try:
@@ -38,6 +86,7 @@ def _connect() -> "psycopg2.extensions.connection":
         raise SystemExit(2) from e
 
 
+# ─── Claude backend ───────────────────────────────────────────────────────────
 def _resolve_claude_bin() -> str:
     env = os.environ.get("CLAUDE_BIN")
     if env:
@@ -47,122 +96,280 @@ def _resolve_claude_bin() -> str:
     return found or "claude"
 
 
+CLAUDE_BIN = _resolve_claude_bin()
+
+
+def _claude_present() -> bool:
+    """True if the Claude CLI binary can be found (without exiting)."""
+    from shutil import which
+    return which(CLAUDE_BIN) is not None or os.path.isfile(CLAUDE_BIN)
+
+
 def _require_claude_bin() -> str:
     """Resolve the Claude CLI binary or emit a clear error and exit."""
-    bin_path = _resolve_claude_bin()
-    from shutil import which
-    if which(bin_path) is None and not os.path.isfile(bin_path):
+    if not _claude_present():
         sys.stderr.write(
             "ERROR: Claude CLI not found.\n"
             "  Set $CLAUDE_BIN or install the Claude Code CLI:\n"
             "    https://docs.anthropic.com/en/docs/claude-code/setup\n"
         )
         raise SystemExit(2)
-    return bin_path
-
-
-CLAUDE_BIN = _resolve_claude_bin()
-MODEL = "sonnet"
-MAX_PER_RUN = 50
-MAX_PREVIEW_CHARS = 4000
-SLEEP = 1.5
-TIMEOUT = 60
-
-PROMPT = """Du bekommst einen Auszug aus einer Claude Code Session. Generiere einen prägnanten deutschen Titel (max 60 Zeichen) der den INHALT zusammenfasst.
-
-Regeln:
-- Kurz und konkret — kein "Hilfe bei..." oder "Session über..."
-- Inhaltsspezifisch: Technologie/Thema nennen
-- KEINE Anführungszeichen, KEINE Punkte am Ende
-- Format: Nomen-Phrase oder Aktion ("PostgreSQL Memory-DB aufsetzen", "Project Alpha Kickoff-Protokoll")
-
-Beispiele guter Titel:
-- "Claude Memory: Schema + Ingestion"
-- "Mail Drafter Skill + launchd Scheduler"
-- "Project Alpha E2E-Testing Strategie"
-- "Diary Automation for Notes App"
-
-Session-Auszug:
-
-{TRANSCRIPT}
-
-Gib NUR den Titel zurück, sonst nichts. Keine Anführungszeichen, keine Erklärung."""
-
-
-def build_preview(messages: list[tuple[str, str | None]]) -> str:
-    """Baut kurzen Transcript-Preview für Titel-Generation."""
-    parts = []
-    total = 0
-    for role, content in messages:
-        if role == "tool_result":
-            continue
-        if not content:
-            continue
-        text = content[:500] if len(content) > 500 else content
-        parts.append(f"[{role}] {text}")
-        total += len(text)
-        if total > MAX_PREVIEW_CHARS:
-            break
-    return "\n".join(parts)[:MAX_PREVIEW_CHARS]
+    return CLAUDE_BIN
 
 
 def call_claude(prompt: str) -> str:
     try:
         r = subprocess.run(
             [CLAUDE_BIN, "-p", prompt, "--model", MODEL],
-            capture_output=True, text=True, timeout=TIMEOUT
+            capture_output=True, text=True, timeout=TIMEOUT_CLAUDE
         )
         if r.returncode != 0:
             return ""
-        # Bereinige Output
-        title = r.stdout.strip()
-        # Anführungszeichen entfernen
-        title = title.strip('"').strip("'").strip("„").strip("«").strip("»").rstrip(".")
-        # Erste Zeile nehmen falls mehrere
-        title = title.split("\n")[0].strip()
-        # Max 80 Zeichen
-        if len(title) > 80:
-            title = title[:77] + "..."
-        return title
+        return r.stdout
     except Exception as e:
-        print(f"  Fehler: {e}")
+        print(f"  Fehler (claude): {e}")
         return ""
 
 
-def main() -> None:
+# ─── Ollama backend (local) ────────────────────────────────────────────────
+def ollama_url() -> str:
+    raw = os.environ.get("OLLAMA_HOST") or os.environ.get("OLLAMA_URL") or "http://localhost:11434"
+    return raw.rstrip("/")
+
+
+def ollama_up() -> bool:
+    try:
+        with urllib.request.urlopen(f"{ollama_url()}/api/tags", timeout=2) as r:
+            return r.status == 200
+    except Exception:
+        return False
+
+
+def ollama_list_models() -> list[str]:
+    try:
+        with urllib.request.urlopen(f"{ollama_url()}/api/tags", timeout=5) as r:
+            data = json.loads(r.read().decode("utf-8"))
+        return [m.get("name", "") for m in data.get("models", []) if m.get("name")]
+    except Exception:
+        return []
+
+
+def pick_ollama_chat_model(model_names: list[str], preferred: str | None = None) -> str | None:
+    """Pick a chat-capable Ollama model.
+
+    Honours ``preferred`` if it is actually pulled (exact or tag-prefix match),
+    otherwise returns the first model that is not an embedding model. Returns
+    ``None`` when nothing chat-capable is available.
+    """
+    names = [n for n in (model_names or []) if n]
+    if preferred:
+        for n in names:
+            if n == preferred or n.startswith(preferred):
+                return n
+    chat = [n for n in names if not any(h in n.lower() for h in EMBED_HINTS)]
+    return chat[0] if chat else None
+
+
+def _ollama_generate(body: dict, timeout: int) -> str:
+    req = urllib.request.Request(
+        f"{ollama_url()}/api/generate",
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.loads(r.read().decode("utf-8")).get("response", "")
+
+
+def call_ollama(prompt: str, model: str, timeout: int = TIMEOUT_OLLAMA) -> str:
+    # Disable the model's chain-of-thought: a summary needs no reasoning trace,
+    # and on a "thinking" model like qwen3 it is the difference between seconds
+    # and minutes per call. Fall back gracefully on older Ollama that rejects
+    # the `think` field, and strip any stray <think> block either way.
+    base = {"model": model, "prompt": prompt, "stream": False, "options": {"temperature": 0.2}}
+    try:
+        try:
+            raw = _ollama_generate({**base, "think": False}, timeout)
+        except urllib.error.HTTPError:
+            raw = _ollama_generate(base, timeout)
+        return _THINK_RE.sub("", raw)
+    except Exception as e:
+        print(f"  Fehler (ollama): {e}")
+        return ""
+
+
+def choose_backend(requested: str, *, ollama_available: bool, claude_available: bool) -> str | None:
+    """Resolve the effective backend. ``auto`` prefers local Ollama, falls back
+    to Claude. Returns ``None`` when the request cannot be satisfied."""
+    if requested == "ollama":
+        return "ollama" if ollama_available else None
+    if requested == "claude":
+        return "claude" if claude_available else None
+    # auto
+    if ollama_available:
+        return "ollama"
+    if claude_available:
+        return "claude"
+    return None
+
+
+def generate(prompt: str, backend: str, ollama_model: str | None = None) -> str:
+    if backend == "ollama":
+        return call_ollama(prompt, ollama_model or "")
+    return call_claude(prompt)
+
+
+# ─── Transcript preview + cleanup (pure) ─────────────────────────────────────
+def _clean_messages(messages: list[tuple[str, str | None]]) -> list[str]:
+    parts = []
+    for role, content in messages:
+        if role == "tool_result" or not content:
+            continue
+        parts.append(f"[{role}] {content[:MAX_MSG_CHARS]}")
+    return parts
+
+
+def build_preview(messages: list[tuple[str, str | None]], max_chars: int = MAX_PREVIEW_CHARS) -> str:
+    """Build a transcript preview that reflects the WHOLE session.
+
+    Short sessions are returned in full. Long sessions are sampled: a slice
+    from the beginning, one from the middle and one from the end, with markers
+    where content was dropped — so a summary describes the whole arc, not just
+    the opening. Never exceeds ``max_chars``.
+    """
+    parts = _clean_messages(messages)
+    if not parts:
+        return ""
+    full = "\n".join(parts)
+    if len(full) <= max_chars:
+        return full
+
+    sep_mid = "\n\n[… Mitte der Session ausgelassen …]\n\n"
+    sep_end = "\n\n[… gegen Ende der Session …]\n\n"
+    budget = max_chars - len(sep_mid) - len(sep_end)
+    if budget < 3:
+        return full[:max_chars]
+
+    head_n = int(budget * 0.4)
+    tail_n = int(budget * 0.4)
+    mid_n = budget - head_n - tail_n
+    head = full[:head_n]
+    tail = full[len(full) - tail_n:]
+    mid_start = max(head_n, len(full) // 2 - mid_n // 2)
+    mid = full[mid_start: mid_start + mid_n]
+    return head + sep_mid + mid + sep_end + tail
+
+
+def clean_summary(raw: str) -> str:
+    """Normalise a model response into a single-paragraph description."""
+    s = (raw or "").strip()
+    s = _THINK_RE.sub("", s).strip()
+    quote_pairs = [('"', '"'), ("'", "'"), ("„", "“"), ("«", "»"), ("»", "«"), ("“", "”")]
+    changed = True
+    while changed and len(s) >= 2:
+        changed = False
+        for a, b in quote_pairs:
+            if s.startswith(a) and s.endswith(b) and len(s) > len(a) + len(b) - 1:
+                s = s[len(a):len(s) - len(b)].strip()
+                changed = True
+    s = " ".join(s.split())
+    if len(s) > MAX_SUMMARY_CHARS:
+        s = s[:MAX_SUMMARY_CHARS - 1].rstrip() + "…"
+    return s
+
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+def _parse_args(argv: list[str] | None = None):
+    import argparse
+    ap = argparse.ArgumentParser(
+        description="Erzeugt klare Beschreibungen (Anfang / was gemacht / Ergebnis) für Conversations."
+    )
+    ap.add_argument("--backend", choices=["auto", "ollama", "claude"], default="auto",
+                    help="Backend-Auswahl. auto = erst Ollama lokal, sonst Claude.")
+    ap.add_argument("--ollama-model", default=(os.environ.get("THROUGHLINE_OLLAMA_CHAT_MODEL")
+                                               or os.environ.get("OLLAMA_CHAT_MODEL")),
+                    help="Ollama-Chat-Modell erzwingen (sonst automatisch erkannt).")
+    ap.add_argument("--force", action="store_true",
+                    help="Auch vorhandene Beschreibungen überschreiben.")
+    ap.add_argument("--conversation", type=int, action="append",
+                    help="Nur diese Conversation-ID(s). Mehrfach möglich.")
+    ap.add_argument("--project", help="Nur Conversations dieses Projekts (project_name).")
+    ap.add_argument("--limit", type=int, default=MAX_PER_RUN,
+                    help=f"Maximale Anzahl pro Lauf (Default {MAX_PER_RUN}).")
+    return ap.parse_args(argv)
+
+
+def main() -> int:
+    args = _parse_args()
+
     print("=" * 60)
-    print("Claude Memory — Titel-Generierung")
+    print("Throughline — Conversation-Beschreibungen")
     print("=" * 60)
 
-    _require_claude_bin()
+    models = ollama_list_models() if ollama_up() else []
+    ollama_model = pick_ollama_chat_model(models, preferred=args.ollama_model)
+    ollama_available = ollama_model is not None
+    claude_available = _claude_present()
+
+    backend = choose_backend(args.backend, ollama_available=ollama_available,
+                             claude_available=claude_available)
+    if backend is None:
+        sys.stderr.write(
+            "ERROR: Kein nutzbares Backend.\n"
+            f"  Ollama erreichbar: {ollama_up()} | Chat-Modell: {ollama_model or '—'}\n"
+            f"  Claude CLI vorhanden: {claude_available}\n"
+            "  Ziehe ein Ollama-Chat-Modell (z.B. `ollama pull qwen3`) oder installiere die Claude CLI.\n"
+        )
+        return 2
+    if backend == "claude":
+        _require_claude_bin()
+
+    if backend == "ollama":
+        print(f"Backend: ollama  Modell: {ollama_model}  ({ollama_url()})")
+    else:
+        print(f"Backend: claude  Modell: {MODEL}")
+
     conn = _connect()
     cursor = conn.cursor()
 
-    cursor.execute(f"""
-        SELECT id, project_name, message_count
-        FROM conversations
-        WHERE (summary IS NULL OR summary = '')
-          AND message_count >= 2
-        ORDER BY started_at DESC
-        LIMIT {MAX_PER_RUN}
-    """)
+    where = ["message_count >= 2"]
+    params: list[Any] = []
+    if not args.force:
+        where.append("(summary IS NULL OR summary = '')")
+    if args.conversation:
+        where.append("id = ANY(%s)")
+        params.append(args.conversation)
+    if args.project:
+        where.append("project_name = %s")
+        params.append(args.project)
+    params.append(args.limit)
+
+    cursor.execute(
+        f"SELECT id, project_name, message_count FROM conversations "
+        f"WHERE {' AND '.join(where)} ORDER BY message_count DESC LIMIT %s",
+        params,
+    )
     convs = cursor.fetchall()
 
-    print(f"\n{len(convs)} Conversations ohne Titel\n")
+    verb = "neu zu beschreiben" if not args.force else "zu (über)schreiben"
+    print(f"\n{len(convs)} Conversations {verb}\n")
     if not convs:
         print("Nichts zu tun.")
-        return
+        cursor.close()
+        conn.close()
+        return 0
 
+    sleep = SLEEP_OLLAMA if backend == "ollama" else SLEEP_CLAUDE
     success = 0
     errors = 0
 
     for conv_id, project, msg_count in convs:
-        cursor.execute("""
-            SELECT role::text, content FROM messages
-            WHERE conversation_id = %s AND role IN ('user', 'assistant')
-            ORDER BY created_at
-            LIMIT 30
-        """, (conv_id,))
+        cursor.execute(
+            "SELECT role::text, content FROM messages "
+            "WHERE conversation_id = %s AND role IN ('user', 'assistant') "
+            "ORDER BY created_at",
+            (conv_id,),
+        )
         msgs = cursor.fetchall()
         if not msgs:
             continue
@@ -172,18 +379,18 @@ def main() -> None:
             continue
 
         prompt = PROMPT.replace("{TRANSCRIPT}", preview)
-        title = call_claude(prompt)
+        summary = clean_summary(generate(prompt, backend, ollama_model))
 
-        if not title:
+        if not summary:
             errors += 1
-            print(f"  #{conv_id} ({project or '-'}) → FEHLER")
+            print(f"  #{conv_id} ({project or '-'}, {msg_count} msgs) → FEHLER")
             continue
 
-        cursor.execute("UPDATE conversations SET summary = %s WHERE id = %s", (title, conv_id))
+        cursor.execute("UPDATE conversations SET summary = %s WHERE id = %s", (summary, conv_id))
         conn.commit()
         success += 1
-        print(f"  #{conv_id} ({project or '-'}): {title}")
-        time.sleep(SLEEP)
+        print(f"  #{conv_id} ({project or '-'}, {msg_count} msgs):\n      {summary}")
+        time.sleep(sleep)
 
     print(f"\n{'=' * 60}")
     print(f"Erfolgreich: {success} | Fehler: {errors}")
@@ -191,7 +398,8 @@ def main() -> None:
 
     cursor.close()
     conn.close()
+    return 0 if errors == 0 else 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/test_generate_titles.py
+++ b/tests/test_generate_titles.py
@@ -1,8 +1,15 @@
-"""Tests for scripts/generate_titles.py — title cleanup and preview building."""
+"""Tests for scripts/generate_titles.py.
 
-import pytest
+Covers the pure logic: whole-session preview sampling (beginning + middle +
+end), summary cleanup, Ollama chat-model selection, and backend choice
+(local Ollama preferred, Claude as fallback). The network/subprocess calls
+themselves are exercised live, not here.
+"""
+
 import importlib.util
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parent.parent
 spec = importlib.util.spec_from_file_location(
@@ -13,27 +20,16 @@ spec.loader.exec_module(gt)
 
 
 class TestPreviewBuilding:
-    def test_includes_user_messages(self):
-        messages = [("user", "Hello"), ("assistant", "Hi")]
+    def test_includes_user_and_assistant_messages(self):
+        messages = [("user", "Hello"), ("assistant", "Hi there")]
         preview = gt.build_preview(messages)
         assert "Hello" in preview
-        assert "Hi" in preview
+        assert "Hi there" in preview
 
     def test_skips_tool_result(self):
-        messages = [("user", "Q"), ("tool_result", "OUTPUT"), ("assistant", "A")]
+        messages = [("user", "Q"), ("tool_result", "RAWTOOLOUTPUT"), ("assistant", "A")]
         preview = gt.build_preview(messages)
-        assert "OUTPUT" not in preview
-
-    def test_caps_at_max_chars(self):
-        messages = [("user", "x" * 10000) for _ in range(20)]
-        preview = gt.build_preview(messages)
-        assert len(preview) <= gt.MAX_PREVIEW_CHARS
-
-    def test_truncates_individual_messages(self):
-        messages = [("user", "y" * 1000)]
-        preview = gt.build_preview(messages)
-        # Individual message truncated to 500 chars
-        assert preview.count("y") <= 500
+        assert "RAWTOOLOUTPUT" not in preview
 
     def test_empty_content_skipped(self):
         messages = [("user", None), ("user", ""), ("assistant", "actual content")]
@@ -42,3 +38,88 @@ class TestPreviewBuilding:
 
     def test_empty_list_returns_empty(self):
         assert gt.build_preview([]) == ""
+
+    def test_per_message_truncation(self):
+        messages = [("user", "y" * 5000)]
+        preview = gt.build_preview(messages)
+        assert preview.count("y") <= gt.MAX_MSG_CHARS
+
+    def test_caps_at_max_chars(self):
+        messages = [("user", "x" * 10000) for _ in range(40)]
+        preview = gt.build_preview(messages)
+        assert len(preview) <= gt.MAX_PREVIEW_CHARS
+
+    def test_long_session_samples_beginning_middle_and_end(self):
+        # A session far larger than the budget: the FIRST and LAST turns must
+        # survive (so the summary reflects the whole arc, not just the start),
+        # and the sampler must mark the omitted middle.
+        first = ("user", "ANFANGSTOKEN goal is to set up the data platform")
+        bulk = [("assistant", "z" * 1000) for _ in range(60)]
+        last = ("assistant", "ENDETOKEN platform is live and the pipeline runs")
+        messages = [first, *bulk, last]
+        preview = gt.build_preview(messages)
+        assert len(preview) <= gt.MAX_PREVIEW_CHARS
+        assert "ANFANGSTOKEN" in preview, "beginning of the session was dropped"
+        assert "ENDETOKEN" in preview, "end of the session was dropped"
+        # The whole transcript can't fit, so an omission marker must appear.
+        assert "…" in preview or "..." in preview
+
+
+class TestCleanSummary:
+    def test_strips_surrounding_quotes(self):
+        assert gt.clean_summary('"Eine Beschreibung"') == "Eine Beschreibung"
+        assert gt.clean_summary("„Eine Beschreibung“") == "Eine Beschreibung"
+
+    def test_collapses_to_single_paragraph(self):
+        raw = "Erster Teil.\n\nZweiter Teil.\n  Dritter Teil."
+        out = gt.clean_summary(raw)
+        assert "\n" not in out
+        assert "Erster Teil." in out and "Dritter Teil." in out
+
+    def test_keeps_sentence_punctuation(self):
+        out = gt.clean_summary("Ziel war X. Gemacht wurde Y. Ergebnis ist Z.")
+        assert out.endswith("Z.")
+        assert out.count(".") == 3
+
+    def test_caps_length(self):
+        out = gt.clean_summary("Satz. " * 500)
+        assert len(out) <= gt.MAX_SUMMARY_CHARS
+
+
+class TestPickOllamaChatModel:
+    def test_excludes_embedding_models(self):
+        names = ["nomic-embed-text:latest", "qwen3.6:27b"]
+        assert gt.pick_ollama_chat_model(names) == "qwen3.6:27b"
+
+    def test_prefers_explicit_when_present(self):
+        names = ["nomic-embed-text:latest", "qwen3.6:27b", "llama3.1:8b"]
+        assert gt.pick_ollama_chat_model(names, preferred="llama3.1:8b") == "llama3.1:8b"
+
+    def test_explicit_ignored_when_absent_falls_back_to_chat(self):
+        names = ["nomic-embed-text:latest", "qwen3.6:27b"]
+        assert gt.pick_ollama_chat_model(names, preferred="not-pulled") == "qwen3.6:27b"
+
+    def test_returns_none_when_only_embeddings(self):
+        assert gt.pick_ollama_chat_model(["nomic-embed-text:latest"]) is None
+
+    def test_returns_none_when_empty(self):
+        assert gt.pick_ollama_chat_model([]) is None
+
+
+class TestChooseBackend:
+    def test_auto_prefers_ollama_when_available(self):
+        assert gt.choose_backend("auto", ollama_available=True, claude_available=True) == "ollama"
+
+    def test_auto_falls_back_to_claude_when_no_ollama(self):
+        assert gt.choose_backend("auto", ollama_available=False, claude_available=True) == "claude"
+
+    def test_auto_none_when_nothing_available(self):
+        assert gt.choose_backend("auto", ollama_available=False, claude_available=False) is None
+
+    def test_explicit_ollama_requires_ollama(self):
+        assert gt.choose_backend("ollama", ollama_available=True, claude_available=False) == "ollama"
+        assert gt.choose_backend("ollama", ollama_available=False, claude_available=True) is None
+
+    def test_explicit_claude_requires_claude(self):
+        assert gt.choose_backend("claude", ollama_available=True, claude_available=True) == "claude"
+        assert gt.choose_backend("claude", ollama_available=True, claude_available=False) is None

--- a/throughline/cli.py
+++ b/throughline/cli.py
@@ -163,8 +163,21 @@ def cmd_extract_memory(args: argparse.Namespace) -> int:
 
 
 def cmd_generate_titles(args: argparse.Namespace) -> int:
-    """Generate concise titles for conversations that are missing one."""
-    return _call_script_main("generate_titles")
+    """Generate clear descriptions for conversations (start / work done / outcome)."""
+    passthrough: list[str] = []
+    if args.backend:
+        passthrough += ["--backend", args.backend]
+    if args.ollama_model:
+        passthrough += ["--ollama-model", args.ollama_model]
+    if args.force:
+        passthrough += ["--force"]
+    for conv_id in args.conversation or []:
+        passthrough += ["--conversation", str(conv_id)]
+    if args.project:
+        passthrough += ["--project", args.project]
+    if args.limit is not None:
+        passthrough += ["--limit", str(args.limit)]
+    return _call_script_main("generate_titles", passthrough)
 
 
 def cmd_embed(args: argparse.Namespace) -> int:
@@ -424,8 +437,18 @@ def build_parser() -> argparse.ArgumentParser:
     # generate-titles
     p = sub.add_parser(
         "generate-titles",
-        help="Generate concise titles for conversations missing a summary.",
+        help="Generate clear descriptions (start / work done / outcome) for conversations.",
     )
+    p.add_argument("--backend", choices=["auto", "ollama", "claude"], default="auto",
+                   help="Generation backend. auto = local Ollama first, Claude as fallback.")
+    p.add_argument("--ollama-model", default=None,
+                   help="Force a specific Ollama chat model (otherwise auto-detected).")
+    p.add_argument("--force", action="store_true",
+                   help="Also overwrite conversations that already have a description.")
+    p.add_argument("--conversation", type=int, action="append",
+                   help="Limit to these conversation id(s). Repeatable.")
+    p.add_argument("--project", help="Limit to one project (project_name).")
+    p.add_argument("--limit", type=int, default=None, help="Max conversations per run.")
     p.set_defaults(func=cmd_generate_titles)
 
     # embed


### PR DESCRIPTION
## Problem

`generate-titles` built its preview from only the **first ~4000 chars** of a session and asked for a **≤60-char title**. For long sessions that meant the description reflected the opening alone. A 4102-message session showed up as just *"JIRA CSV Export zu Excel Dashboard analysiert"* — which made it look like most of the work was missing.

## Change

- **Whole-session sampling.** `build_preview` now samples the beginning, the middle and the end of the session (with markers where spans are dropped), so the description covers the full arc instead of just the start.
- **Richer output.** New prompt asks for a 2–4 sentence German paragraph covering *start → work done → outcome*, stored in `conversations.summary` (cap 800 chars).
- **Local-first backend.** A local Ollama backend is now the default — nothing leaves the machine — with the existing hosted CLI path as fallback. `--backend auto|ollama|claude`. Chain-of-thought is disabled for speed (seconds vs minutes on a thinking model like qwen3), with a graceful fallback for older Ollama that rejects the field, plus `<think>`-block stripping.
- **New flags:** `--force` (overwrite existing), `--conversation`, `--project`, `--limit`, `--ollama-model` — wired through the CLI.

## Before / after (real session #101, 4102 msgs, local qwen3, ~23s)

**Before:** `JIRA CSV Export zu Excel Dashboard analysiert`

**After:** *Die Session begann mit der Analyse von JIRA-CSV-Exporten zur Erstellung einer Excel-Datenbank mit Dashboards … Anschließend wurde ein umfassender Word-Bericht über das Sizing von MSSQL-Datenbanken (Artelis_Prod und Migration) erstellt … Zum Abschluss wurde ein vollständiger Excel-Export aller JIRA-Elemente mit 1.037 Issues generiert, um die spätere Extraktion von Testfällen zu ermöglichen.*

## Tests

`tests/test_generate_titles.py` covers the pure logic: whole-session sampling (beginning + middle + end survive, omission marked, within budget), summary cleanup (quote stripping, single paragraph, length cap), chat-model selection (excludes embedding models, honours an explicit pick), and backend choice (local-first, fallback, explicit). Network/subprocess calls are exercised live.

Full unit suite: **311 passed, 1 skipped** (pre-existing `mcp` skip).