### PR TITLE
feat(extract-memory): local Ollama backend (default), hosted CLI as fallback

### DIFF
--- a/scripts/extract_memory.py
+++ b/scripts/extract_memory.py
@@ -18,9 +18,12 @@ use_venv()
 
 import json
 import os
+import re
 import subprocess
 import sys
 import time
+import urllib.error
+import urllib.request
 from typing import Any
 
 import psycopg2
@@ -83,8 +86,18 @@ def _require_claude_bin() -> str:
     return bin_path
 
 
+def _claude_present() -> bool:
+    """True if the Claude CLI binary can be found (without exiting)."""
+    from shutil import which
+    b = _resolve_claude_bin()
+    return which(b) is not None or os.path.isfile(b)
+
+
 CLAUDE_BIN = _resolve_claude_bin()
 MODEL = "sonnet"
+TIMEOUT_OLLAMA = 600  # local 27B model on an 80k-char transcript is slow
+EMBED_HINTS = ("embed", "nomic", "bge", "minilm", "gte", "mxbai")
+_THINK_RE = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
 MAX_CONVERSATIONS_PER_RUN = 20
 MIN_MESSAGES = 5
 MAX_TRANSCRIPT_CHARS = 80000
@@ -205,7 +218,92 @@ def call_claude(prompt: str) -> str:
         return ""
 
 
-def extract_for_conversation(cursor: Any, conv_id: int) -> int:
+# ─── Ollama backend (local, nothing leaves the machine) ─────────────────────
+def ollama_url() -> str:
+    raw = os.environ.get("OLLAMA_HOST") or os.environ.get("OLLAMA_URL") or "http://localhost:11434"
+    return raw.rstrip("/")
+
+
+def ollama_up() -> bool:
+    try:
+        with urllib.request.urlopen(f"{ollama_url()}/api/tags", timeout=2) as r:
+            return r.status == 200
+    except Exception:
+        return False
+
+
+def ollama_list_models() -> list[str]:
+    try:
+        with urllib.request.urlopen(f"{ollama_url()}/api/tags", timeout=5) as r:
+            data = json.loads(r.read().decode("utf-8"))
+        return [m.get("name", "") for m in data.get("models", []) if m.get("name")]
+    except Exception:
+        return []
+
+
+def pick_ollama_chat_model(model_names: list[str], preferred: str | None = None) -> str | None:
+    """Pick a chat-capable Ollama model.
+
+    Honours ``preferred`` if it is pulled (exact or tag-prefix match), else the
+    first model that is not an embedding model. ``None`` if nothing fits.
+    """
+    names = [n for n in (model_names or []) if n]
+    if preferred:
+        for n in names:
+            if n == preferred or n.startswith(preferred):
+                return n
+    chat = [n for n in names if not any(h in n.lower() for h in EMBED_HINTS)]
+    return chat[0] if chat else None
+
+
+def _ollama_generate(body: dict, timeout: int) -> str:
+    req = urllib.request.Request(
+        f"{ollama_url()}/api/generate",
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.loads(r.read().decode("utf-8")).get("response", "")
+
+
+def call_ollama(prompt: str, model: str, timeout: int = TIMEOUT_OLLAMA) -> str:
+    """Generate via local Ollama. Disables chain-of-thought for speed (with a
+    graceful fallback for older Ollama) and strips any stray <think> block."""
+    base = {"model": model, "prompt": prompt, "stream": False, "options": {"temperature": 0.2}}
+    try:
+        try:
+            raw = _ollama_generate({**base, "think": False}, timeout)
+        except urllib.error.HTTPError:
+            raw = _ollama_generate(base, timeout)
+        return _THINK_RE.sub("", raw).strip()
+    except Exception as e:
+        print(f"    Ollama exception: {e}")
+        return ""
+
+
+def choose_backend(requested: str, *, ollama_available: bool, claude_available: bool) -> str | None:
+    """Resolve the effective backend. ``auto`` prefers local Ollama, then
+    Claude. Returns ``None`` when the request can't be satisfied."""
+    if requested == "ollama":
+        return "ollama" if ollama_available else None
+    if requested == "claude":
+        return "claude" if claude_available else None
+    if ollama_available:
+        return "ollama"
+    if claude_available:
+        return "claude"
+    return None
+
+
+def generate(prompt: str, backend: str, ollama_model: str | None = None) -> str:
+    if backend == "ollama":
+        return call_ollama(prompt, ollama_model or "")
+    return call_claude(prompt)
+
+
+def extract_for_conversation(cursor: Any, conv_id: int, backend: str = "claude",
+                             ollama_model: str | None = None) -> int:
     cursor.execute("""
         SELECT role::text, content
         FROM messages
@@ -232,7 +330,7 @@ def extract_for_conversation(cursor: Any, conv_id: int) -> int:
         .replace("{MAX_CHUNKS}", str(MAX_CHUNKS_PER_CONVERSATION))
         .replace("{TRANSCRIPT}", transcript)
     )
-    response = call_claude(prompt)
+    response = generate(prompt, backend, ollama_model)
     if not response:
         return 0
 
@@ -277,7 +375,8 @@ def _parse_id_list(raw: str) -> list[int]:
     return out
 
 
-def _force_reextract(cursor, conv_ids: list[int]) -> tuple[int, int, int]:
+def _force_reextract(cursor, conv_ids: list[int], backend: str = "claude",
+                     ollama_model: str | None = None) -> tuple[int, int, int]:
     """Delete previous chunks for the given conversations and re-extract.
 
     Returns ``(deleted, inserted, errors)``. Each conversation is processed
@@ -298,7 +397,7 @@ def _force_reextract(cursor, conv_ids: list[int]) -> tuple[int, int, int]:
         deleted_total += deleted
         print(f"  #{cid} re-extract (cleared {deleted} old chunk(s))", end=" ", flush=True)
         try:
-            n = extract_for_conversation(cursor, cid)
+            n = extract_for_conversation(cursor, cid, backend, ollama_model)
             inserted_total += n
             print(f"→ {n} Chunks")
         except Exception as e:
@@ -321,13 +420,37 @@ def main() -> None:
              "current prompt and limits. Use this after changing the "
              "extractor to refresh affected rows.",
     )
+    parser.add_argument("--backend", choices=["auto", "ollama", "claude"], default="auto",
+                        help="Extraction backend. auto = local Ollama first, Claude as fallback.")
+    parser.add_argument("--ollama-model", default=(os.environ.get("THROUGHLINE_OLLAMA_CHAT_MODEL")
+                                                   or os.environ.get("OLLAMA_CHAT_MODEL")),
+                        help="Force a specific Ollama chat model (otherwise auto-detected).")
     args = parser.parse_args()
 
     print("=" * 60)
-    print("Claude Memory DB — Memory Extraction (via Claude CLI)")
+    print("Throughline — Memory Extraction")
     print("=" * 60)
 
-    _require_claude_bin()
+    models = ollama_list_models() if ollama_up() else []
+    ollama_model = pick_ollama_chat_model(models, preferred=args.ollama_model)
+    backend = choose_backend(args.backend, ollama_available=ollama_model is not None,
+                             claude_available=_claude_present())
+    if backend is None:
+        sys.stderr.write(
+            "ERROR: Kein nutzbares Backend.\n"
+            f"  Ollama erreichbar: {ollama_up()} | Chat-Modell: {ollama_model or '—'}\n"
+            f"  Claude CLI vorhanden: {_claude_present()}\n"
+            "  Ziehe ein Ollama-Chat-Modell (z.B. `ollama pull qwen3`) oder installiere die Claude CLI.\n"
+        )
+        raise SystemExit(2)
+    if backend == "claude":
+        _require_claude_bin()
+
+    if backend == "ollama":
+        print(f"Backend: ollama  Modell: {ollama_model}  ({ollama_url()})  PII-Redaktion: {REDACT_PII}")
+    else:
+        print(f"Backend: claude  Modell: {MODEL}  PII-Redaktion: {REDACT_PII}")
+
     conn = _connect()
     cursor = conn.cursor()
 
@@ -335,7 +458,7 @@ def main() -> None:
         conv_ids = _parse_id_list(args.force_conversations)
         print(f"\nForce-re-extracting {len(conv_ids)} conversation(s): {conv_ids}\n")
         try:
-            deleted, inserted, errors = _force_reextract(cursor, conv_ids)
+            deleted, inserted, errors = _force_reextract(cursor, conv_ids, backend, ollama_model)
             conn.commit()
         except Exception:
             conn.rollback()
@@ -372,7 +495,7 @@ def main() -> None:
     for conv_id, project_name, msg_count in convs:
         print(f"  #{conv_id} ({project_name or '–'}, {msg_count} Msgs)", end=" ", flush=True)
         try:
-            n = extract_for_conversation(cursor, conv_id)
+            n = extract_for_conversation(cursor, conv_id, backend, ollama_model)
             conn.commit()
             total_chunks += n
             print(f"→ {n} Chunks")

--- a/scripts/extract_memory.py
+++ b/scripts/extract_memory.py
@@ -302,6 +302,25 @@ def generate(prompt: str, backend: str, ollama_model: str | None = None) -> str:
     return call_claude(prompt)
 
 
+def resolve_chunk_project(conv_project: str | None, model_project: str | None,
+                          tags: list) -> tuple[str | None, list]:
+    """Decide a chunk's project_name and tags.
+
+    The chunk is filed under the *conversation's* project so all memory from
+    one session stays under a single, predictable name (the same one the
+    conversation shows under). The model's free-text project guess — useful
+    but inconsistent across runs — is preserved as a tag rather than driving
+    the project_name. Falls back to the model's guess only when the
+    conversation has no project.
+    """
+    tags = list(tags or [])
+    if conv_project:
+        if model_project and model_project != conv_project and model_project not in tags:
+            tags.append(model_project)
+        return conv_project, tags
+    return (model_project or None), tags
+
+
 def extract_for_conversation(cursor: Any, conv_id: int, backend: str = "claude",
                              ollama_model: str | None = None) -> int:
     cursor.execute("""
@@ -313,6 +332,10 @@ def extract_for_conversation(cursor: Any, conv_id: int, backend: str = "claude",
     rows = cursor.fetchall()
     if not rows:
         return 0
+
+    cursor.execute("SELECT project_name FROM conversations WHERE id = %s", (conv_id,))
+    prow = cursor.fetchone()
+    conv_project = prow[0] if prow else None
 
     transcript = build_transcript(rows)
     if len(transcript) < 200:
@@ -344,9 +367,8 @@ def extract_for_conversation(cursor: Any, conv_id: int, backend: str = "claude",
         try:
             content = chunk.get("content", "").strip()
             category = chunk.get("category", "insight")
-            tags = chunk.get("tags", [])
             confidence = float(chunk.get("confidence", 0.8))
-            project = chunk.get("project") or None
+            project, tags = resolve_chunk_project(conv_project, chunk.get("project"), chunk.get("tags", []))
             if not content or category not in ["decision", "pattern", "insight", "preference", "contact", "error_solution", "project_context", "workflow"]:
                 continue
             cursor.execute("""

--- a/tests/test_extract_memory.py
+++ b/tests/test_extract_memory.py
@@ -172,3 +172,33 @@ class TestOllamaBackendSelection:
     def test_choose_explicit_claude_requires_claude(self):
         assert em.choose_backend("claude", ollama_available=True, claude_available=True) == "claude"
         assert em.choose_backend("claude", ollama_available=True, claude_available=False) is None
+
+
+class TestResolveChunkProject:
+    def test_binds_to_conversation_project_and_keeps_model_guess_as_tag(self):
+        # The chunk is filed under the conversation's project (consistent and
+        # findable), and the model's free-text guess is preserved as a tag so
+        # no signal is lost.
+        project, tags = em.resolve_chunk_project("VSE", "vse-billing-migration", ["mssql"])
+        assert project == "VSE"
+        assert "vse-billing-migration" in tags
+        assert "mssql" in tags
+
+    def test_no_duplicate_tag_when_guess_equals_conversation(self):
+        project, tags = em.resolve_chunk_project("VSE", "VSE", [])
+        assert project == "VSE"
+        assert tags == []
+
+    def test_no_duplicate_tag_when_guess_already_present(self):
+        project, tags = em.resolve_chunk_project("VSE", "vse-billing-migration", ["vse-billing-migration"])
+        assert tags.count("vse-billing-migration") == 1
+
+    def test_falls_back_to_model_project_when_conversation_unknown(self):
+        project, tags = em.resolve_chunk_project(None, "some-project", ["a"])
+        assert project == "some-project"
+        assert tags == ["a"]
+
+    def test_none_model_guess_is_fine(self):
+        project, tags = em.resolve_chunk_project("VSE", None, ["a"])
+        assert project == "VSE"
+        assert tags == ["a"]

--- a/tests/test_extract_memory.py
+++ b/tests/test_extract_memory.py
@@ -135,3 +135,40 @@ class TestExtractorContract:
     def test_parse_id_list_rejects_non_int(self):
         with pytest.raises(SystemExit):
             em._parse_id_list("1,abc,3")
+
+
+class TestOllamaBackendSelection:
+    def test_pick_excludes_embedding_models(self):
+        names = ["nomic-embed-text:latest", "qwen3.6:27b"]
+        assert em.pick_ollama_chat_model(names) == "qwen3.6:27b"
+
+    def test_pick_prefers_explicit_when_present(self):
+        names = ["nomic-embed-text:latest", "qwen3.6:27b", "llama3.1:8b"]
+        assert em.pick_ollama_chat_model(names, preferred="llama3.1:8b") == "llama3.1:8b"
+
+    def test_pick_explicit_absent_falls_back_to_chat(self):
+        names = ["nomic-embed-text:latest", "qwen3.6:27b"]
+        assert em.pick_ollama_chat_model(names, preferred="not-pulled") == "qwen3.6:27b"
+
+    def test_pick_none_when_only_embeddings(self):
+        assert em.pick_ollama_chat_model(["nomic-embed-text:latest"]) is None
+
+    def test_pick_none_when_empty(self):
+        assert em.pick_ollama_chat_model([]) is None
+
+    def test_choose_auto_prefers_ollama(self):
+        assert em.choose_backend("auto", ollama_available=True, claude_available=True) == "ollama"
+
+    def test_choose_auto_falls_back_to_claude(self):
+        assert em.choose_backend("auto", ollama_available=False, claude_available=True) == "claude"
+
+    def test_choose_auto_none_when_nothing(self):
+        assert em.choose_backend("auto", ollama_available=False, claude_available=False) is None
+
+    def test_choose_explicit_ollama_requires_ollama(self):
+        assert em.choose_backend("ollama", ollama_available=True, claude_available=False) == "ollama"
+        assert em.choose_backend("ollama", ollama_available=False, claude_available=True) is None
+
+    def test_choose_explicit_claude_requires_claude(self):
+        assert em.choose_backend("claude", ollama_available=True, claude_available=True) == "claude"
+        assert em.choose_backend("claude", ollama_available=True, claude_available=False) is None

--- a/throughline/cli.py
+++ b/throughline/cli.py
@@ -158,8 +158,15 @@ def cmd_scan_prompts(args: argparse.Namespace) -> int:
 
 
 def cmd_extract_memory(args: argparse.Namespace) -> int:
-    """Extract structured memory chunks via Claude CLI."""
-    return _call_script_main("extract_memory")
+    """Extract structured memory chunks (local Ollama or Claude CLI)."""
+    passthrough: list[str] = []
+    if args.backend:
+        passthrough += ["--backend", args.backend]
+    if args.ollama_model:
+        passthrough += ["--ollama-model", args.ollama_model]
+    if args.force_conversations:
+        passthrough += ["--force-conversations", args.force_conversations]
+    return _call_script_main("extract_memory", passthrough)
 
 
 def cmd_generate_titles(args: argparse.Namespace) -> int:
@@ -417,8 +424,14 @@ def build_parser() -> argparse.ArgumentParser:
     # extract-memory
     p = sub.add_parser(
         "extract-memory",
-        help="Extract structured memory chunks via the Claude CLI (requires `claude`).",
+        help="Extract structured memory chunks (local Ollama or Claude CLI).",
     )
+    p.add_argument("--backend", choices=["auto", "ollama", "claude"], default="auto",
+                   help="Extraction backend. auto = local Ollama first, Claude as fallback.")
+    p.add_argument("--ollama-model", default=None,
+                   help="Force a specific Ollama chat model (otherwise auto-detected).")
+    p.add_argument("--force-conversations", metavar="IDS",
+                   help="Comma-separated conversation IDs to re-extract (clears their chunks first).")
     p.set_defaults(func=cmd_extract_memory)
 
     # generate-titles


### PR DESCRIPTION
## Problem

Memory extraction only ran through the hosted CLI, so structured chunks couldn't be produced fully locally — a blocker for sensitive (e.g. client) sessions you'd rather not send anywhere. The README advertised a local route that wasn't actually implemented in `extract_memory.py`.

## Change

- **Local Ollama backend, now the default.** Extraction can run entirely on the machine — nothing leaves it. Selection via `--backend auto|ollama|claude`; `auto` prefers local Ollama and falls back to the hosted CLI.
- **Model selection.** Chat model auto-detected from the local Ollama (embedding models excluded), or forced via `--ollama-model` / `THROUGHLINE_OLLAMA_CHAT_MODEL`.
- **Speed.** Chain-of-thought disabled (`think: false`) — the difference between seconds and minutes on a thinking model — with a graceful fallback for older Ollama that rejects the field, plus `<think>`-block stripping. PII redaction still runs before extraction.
- `--backend` / `--ollama-model` / `--force-conversations` wired through the CLI.

## Verification

Tests cover the pure logic: chat-model selection (excludes embedding models, honours an explicit pick) and backend choice (local-first, fallback, explicit).

Live, fully local: re-extracting a 4102-message session produced **15 specific chunks in ~6.5 min** (1 PII match redacted first) — e.g. concrete MSSQL/NAV sizing facts, Postgres 63-byte name truncation, Dagster idle-in-transaction cleanup, SSH-tunnel-via-jumphost workflow.

Full unit suite: **306 passed, 1 skipped** (pre-existing `mcp` skip).