### PR TITLE
fix(adapter/claude_code): broaden filter to all pipeline echo prompts

### DIFF
--- a/tests/test_adapter_claude_code.py
+++ b/tests/test_adapter_claude_code.py
@@ -139,18 +139,44 @@ class TestClaudeCodeAdapter:
         assert conv is not None
         assert conv.session_id == real_sid
 
-    def test_skips_title_generator_echo_sessions(self, tmp_path):
-        # Each headless `claude -p` call issued by scripts/generate_titles.py
-        # gets logged as its own Claude Code session. Without this filter the
-        # ingest re-imports them, producing hundreds of duplicate
-        # "Session-Titel-Generator" rows. The adapter must drop them.
+    @pytest.mark.parametrize(
+        "first_user_prompt",
+        [
+            # generate_titles.py
+            "Du bekommst einen Auszug aus einer Claude Code Session. "
+            "Generiere einen prägnanten deutschen Titel (max 60 Zeichen) …",
+            # extract_entities.py
+            "Du analysierst ein Session-Transcript und extrahierst "
+            "strukturierte Entitäten + Beziehungen als JSON. …",
+            # extract_memory.py (current phrasing)
+            "Du analysierst eine Entwickler-Session (Claude Code, Codex, "
+            "Hermes, Continue, Windsurf, Cline) und extrahierst …",
+            # extract_memory.py (older phrasing still present in ~/.claude)
+            "Du analysierst eine Claude Code Entwickler-Session und "
+            "extrahierst verwertbare Erkenntnisse …",
+            # reflect_memory.py — DEDUP
+            "Du bekommst zwei Memory-Chunks aus einer persoenlichen "
+            "Wissensdatenbank. …",
+            # reflect_memory.py — MERGE
+            "Du bekommst zwei Memory-Chunks die denselben Sachverhalt "
+            "beschreiben. …",
+            # reflect_memory.py — CONTRA
+            "Zwei Memory-Chunks aus einer persoenlichen Wissensdatenbank …",
+            # reflect_memory.py — STALE
+            "Ein Memory-Chunk aus einer persoenlichen Wissensdatenbank: …",
+            # reflect_memory.py — CONSOLIDATE
+            "Du bekommst mehrere Memory-Chunks zum gleichen Thema. …",
+        ],
+    )
+    def test_skips_internal_pipeline_echo_sessions(self, tmp_path, first_user_prompt):
+        # Every headless `claude -p` call issued by scripts/*.py is itself
+        # logged as its own Claude Code session. Without this filter the
+        # ingest re-imports them, producing hundreds of duplicate meta rows.
+        # The adapter must drop them — covering title-gen, entity extraction,
+        # memory extraction, and every reflect-memory prompt shape.
         sid = str(uuid.uuid4())
         ts = datetime(2026, 1, 15, 10, 0, 0, tzinfo=timezone.utc).isoformat()
         path = tmp_path / f"{sid}.jsonl"
-        prompt = (
-            "Du bekommst einen Auszug aus einer Claude Code Session. "
-            "Generiere einen prägnanten deutschen Titel (max 60 Zeichen) ..."
-        )
         _write_jsonl(
             path,
             [
@@ -158,7 +184,7 @@ class TestClaudeCodeAdapter:
                     "type": "user",
                     "uuid": str(uuid.uuid4()),
                     "isSidechain": False,
-                    "message": {"role": "user", "content": prompt},
+                    "message": {"role": "user", "content": first_user_prompt},
                     "timestamp": ts,
                     "sessionId": sid,
                     "cwd": "/repo/throughline",
@@ -170,7 +196,7 @@ class TestClaudeCodeAdapter:
                     "message": {
                         "role": "assistant",
                         "model": "claude-sonnet-4-6",
-                        "content": [{"type": "text", "text": "Some title"}],
+                        "content": [{"type": "text", "text": "response"}],
                     },
                     "timestamp": ts,
                     "sessionId": sid,

--- a/throughline/adapters/claude_code.py
+++ b/throughline/adapters/claude_code.py
@@ -17,18 +17,47 @@ from typing import Any, Iterable
 
 from .base import Adapter, NormalisedConversation, NormalisedMessage
 
-# Sessions whose first user message starts with this marker are headless
-# `claude -p ...` calls issued by scripts/generate_titles.py. Each such call is
-# itself logged as a Claude Code session, then re-ingested here — producing
-# hundreds of indistinguishable "Session-Titel-Generator" rows. Skip them at
-# the adapter boundary so they never enter the DB.
-_TITLE_GENERATOR_MARKER = (
+# Sessions whose first user message starts with any of these markers are
+# headless `claude -p ...` calls issued by the throughline pipeline scripts
+# themselves (title generation, entity/memory extraction, memory reflection).
+# Each such call is logged by Claude Code as its own JSONL session; without
+# filtering, they get re-ingested on every sync and pollute the DB with
+# hundreds of indistinguishable meta rows.
+#
+# When adding a script that shells out via `claude -p ...`, add its unique
+# prompt prefix here.
+_INTERNAL_PIPELINE_PROMPT_PREFIXES: tuple[str, ...] = (
+    # scripts/generate_titles.py — PROMPT
     "Du bekommst einen Auszug aus einer Claude Code Session. "
-    "Generiere einen prägnanten deutschen Titel"
+    "Generiere einen prägnanten deutschen Titel",
+    # scripts/extract_entities.py — PROMPT_TEMPLATE
+    "Du analysierst ein Session-Transcript und extrahierst strukturierte "
+    "Entitäten",
+    # scripts/extract_memory.py — PROMPT_TEMPLATE (current + older phrasing
+    # that still lingers in ~/.claude/projects on machines that ran earlier
+    # versions of the script).
+    "Du analysierst eine Entwickler-Session (Claude Code, Codex, Hermes",
+    "Du analysierst eine Claude Code Entwickler-Session und extrahierst",
+    # scripts/reflect_memory.py — DEDUP_PROMPT
+    "Du bekommst zwei Memory-Chunks aus einer persoenlichen Wissensdatenbank",
+    # scripts/reflect_memory.py — MERGE_PROMPT
+    "Du bekommst zwei Memory-Chunks die denselben Sachverhalt beschreiben",
+    # scripts/reflect_memory.py — CONTRA_PROMPT
+    "Zwei Memory-Chunks aus einer persoenlichen Wissensdatenbank",
+    # scripts/reflect_memory.py — STALE_PROMPT
+    "Ein Memory-Chunk aus einer persoenlichen Wissensdatenbank",
+    # scripts/reflect_memory.py — CONSOLIDATE_PROMPT
+    "Du bekommst mehrere Memory-Chunks zum gleichen Thema",
 )
 
 
-def _is_title_generator_session(entries: list[dict[str, Any]]) -> bool:
+def _is_internal_pipeline_session(entries: list[dict[str, Any]]) -> bool:
+    """True if the session's first user message is a throughline pipeline prompt.
+
+    Only the first user message is inspected — sessions that merely quote a
+    pipeline prompt later (e.g. while editing scripts/*.py) are still
+    ingested.
+    """
     for e in entries:
         msg = e.get("message")
         if not isinstance(msg, dict) or msg.get("role") != "user":
@@ -42,9 +71,13 @@ def _is_title_generator_session(entries: list[dict[str, Any]]) -> bool:
                 if isinstance(block, dict) and block.get("type") == "text":
                     text = block.get("text")
                     break
-        if text and text.lstrip().startswith(_TITLE_GENERATOR_MARKER):
-            return True
-        return False
+        if not text:
+            return False
+        stripped = text.lstrip()
+        return any(
+            stripped.startswith(prefix)
+            for prefix in _INTERNAL_PIPELINE_PROMPT_PREFIXES
+        )
     return False
 
 
@@ -100,7 +133,7 @@ class ClaudeCodeAdapter(Adapter):
         if not msg_entries:
             return None
 
-        if _is_title_generator_session(msg_entries):
+        if _is_internal_pipeline_session(msg_entries):
             return None
 
         # cwd from the JSONL is the authoritative project_path.


### PR DESCRIPTION
## Problem

PR #30 filtered out `scripts/generate_titles.py` echo sessions but four other pipeline scripts also shell out via `claude -p <prompt>` and produce the same class of meta-conversations on every re-ingest:

- `scripts/extract_entities.py`   — entity / relation extraction
- `scripts/extract_memory.py`     — memory-chunk extraction (2 phrasings; current + older)
- `scripts/reflect_memory.py`     — dedup / merge / contra / stale / consolidate prompts

On a representative local DB, **~360 of 489** sub-5-message conversations were these echoes.

## Fix

Replace the single `_TITLE_GENERATOR_MARKER` with `_INTERNAL_PIPELINE_PROMPT_PREFIXES` — a tuple of every known prompt prefix. Each entry has a comment identifying which script it came from, so future prompts can be added deliberately.

Function renamed `_is_title_generator_session` → `_is_internal_pipeline_session`.

## Test plan
- [x] Tests parametrised over all 9 prefixes (title-gen, entity, extract-memory ×2, reflect-memory ×5)
- [x] `test_does_not_skip_session_that_merely_mentions_generator` still passes — only the *first* user message is inspected
- [x] All 17 adapter tests pass